### PR TITLE
[FEATURE][CULTUREINFO][MAIN] 전시/공연 정보 메인 페이지 Route 추가 및 header 메뉴 페이지 연결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import Layout from './layouts/Layout';
 import GlobalStyles from './styles/GlobalStyles';
 import LoginPage from './pages/login/LoginPage';
 import SignUpPage from './pages/login/SignUp';
+import CultureInfo from './pages/cultureInfo/CultureInfo';
 
 
 export default function App() {
@@ -16,6 +17,7 @@ export default function App() {
             <Route path="/" element={<Layout/>}>
             <Route path='/login' element={<LoginPage/>}/>
             <Route path='/signup' element={<SignUpPage/>}/>
+            <Route path="/cultureinfo" element={<CultureInfo/>}/> {/* 전시/공연 정보 */}
             </Route>                
         </Routes>
     </BrowserRouter>

--- a/src/components/commons/Header.js
+++ b/src/components/commons/Header.js
@@ -13,9 +13,8 @@ function Header() {
           </div>
           <nav>
             <ul>
-              <li>오픈공지</li>
-              <li>열린팟</li>
-              <li>고객센터</li>
+              <li><NavLink to={'/cultureinfo'}>전시/공연정보</NavLink></li>
+              <li>허니팟</li>
             </ul>
           </nav>
           <NavLink to='/login'>

--- a/src/pages/cultureInfo/CultureInfo.js
+++ b/src/pages/cultureInfo/CultureInfo.js
@@ -1,0 +1,10 @@
+//import styles from "./CultureInfo.module.css";
+
+export default function CultureInfo () {
+
+  return(
+    <>
+    <h1>전시/공연 정보 페이지</h1>
+    </>
+    );
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[FEATURE][CULTUREINFO][MAIN] 전시/공연 정보 메인 페이지 레이아웃

### 💡 작업동기
- 전시/공연 정보 메인 페이지 

### 🔑 주요 변경사항
- 1. App.js에 전시/공연 정보 메인 페이지 Route 추가
- 2. Header.js에 '오픈공지'메뉴 이름을 '전시/공연 정보'로 변경 후 Navlink태그 사용하여 페이지 연결
- 3. Header.js의 메인 메뉴 구성 및 이름 변경 - 고객센터 메뉴 제거(footer에 고객센터 메뉴 존재) , 열린팟 메뉴를 '허니팟'으로 변경
### 🏞 스크린샷
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/73331620/0a4d036b-c916-4669-a543-64974429ede1)
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/73331620/2b17e005-a2ec-4d0d-8c7c-c39bec42cac9)

### 관련 이슈
- 관련 이슈를 입력해주세요.

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
