### PR TITLE
[FEATURE][MAIN]메인 페이지 레이아웃 작업

### DIFF
--- a/src/components/main/EarlyBanner.js
+++ b/src/components/main/EarlyBanner.js
@@ -2,6 +2,7 @@ import '../../styles/slick-theme.css';
 import '../../styles/slick.css';
 import mainStyle from '../../pages/main/Main.module.css';
 import Slider from "react-slick";
+import { Link } from 'react-router-dom';
 
 function NextBtn(props) {
   const { className, onClick } = props;
@@ -39,7 +40,7 @@ export default function EarlyBanner() {
     <div className={`slider-container ${mainStyle.common_slide}`}>
       <Slider {...settings}>
         <div className={mainStyle.early_slide_list}>
-          <a href="#" className={mainStyle.flex_start}>
+          <Link to="/cultureinfo/detail" className={mainStyle.flex_start}>
             <div className={mainStyle.early_img}>
               <img src="https://images.unsplash.com/photo-1514525253161-7a46d19cd819?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mzd8fGNvbmNlcnQlMjBwb3N0ZXJ8ZW58MHx8MHx8fDA%3D" alt="early bird info"/>
             </div>
@@ -51,10 +52,10 @@ export default function EarlyBanner() {
               <p className={mainStyle.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
               <p className={mainStyle.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
             </div>
-          </a>
+          </Link>
         </div>
         <div className={mainStyle.early_slide_list}>
-          <a href="#" className={mainStyle.flex_start}>
+          <Link to="/cultureinfo/detail" className={mainStyle.flex_start}>
             <div className={mainStyle.early_img}>
               <img src="https://images.unsplash.com/photo-1598387180437-80388ae0df12?q=80&w=3552&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="early bird info"/>
             </div>
@@ -66,10 +67,10 @@ export default function EarlyBanner() {
               <p className={mainStyle.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
               <p className={mainStyle.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
             </div>
-          </a>
+          </Link>
         </div>
         <div className={mainStyle.early_slide_list}>
-          <a href="#" className={mainStyle.flex_start}>
+          <Link to="/cultureinfo/detail" className={mainStyle.flex_start}>
             <div className={mainStyle.early_img}>
               <img src="https://plus.unsplash.com/premium_photo-1695636587294-5e7eba3e3b43?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8ZmVzdGl2YWwlMjBwb3N0ZXJ8ZW58MHx8MHx8fDA%3D" alt="early bird info"/>
             </div>
@@ -81,10 +82,10 @@ export default function EarlyBanner() {
               <p className={mainStyle.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
               <p className={mainStyle.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
             </div>
-          </a>
+          </Link>
         </div>
         <div className={mainStyle.early_slide_list}>
-          <a href="#" className={mainStyle.flex_start}>
+          <Link to="/cultureinfo/detail" className={mainStyle.flex_start}>
             <div className={mainStyle.early_img}>
               <img src="https://images.unsplash.com/photo-1580130544401-347c796dceec?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NHx8ZXhoaWJpdGlvbiUyMHBvc3RlcnxlbnwwfHwwfHx8MA%3D%3D" alt="early bird info"/>
             </div>
@@ -96,10 +97,10 @@ export default function EarlyBanner() {
               <p className={mainStyle.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
               <p className={mainStyle.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
             </div>
-          </a>
+          </Link>
         </div>
         <div className={mainStyle.early_slide_list}>
-          <a href="#" className={mainStyle.flex_start}>
+          <Link to="/cultureinfo/detail" className={mainStyle.flex_start}>
             <div className={mainStyle.early_img}>
               <img src="https://images.unsplash.com/photo-1530263131525-1c1d26feaa60?q=80&w=3542&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="early bird info"/>
             </div>
@@ -111,7 +112,7 @@ export default function EarlyBanner() {
               <p className={mainStyle.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
               <p className={mainStyle.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
             </div>
-          </a>
+          </Link>
         </div>
       </Slider>
     </div>

--- a/src/components/main/HotBanner.js
+++ b/src/components/main/HotBanner.js
@@ -2,6 +2,7 @@ import '../../styles/slick-theme.css';
 import '../../styles/slick.css';
 import mainStyle from '../../pages/main/Main.module.css';
 import Slider from "react-slick";
+import { Link } from 'react-router-dom';
 
 function NextBtn(props) {
   const { className, onClick } = props;
@@ -39,54 +40,54 @@ export default function HotBanner() {
     <div className={`slider-container ${mainStyle.hot_prf_box} ${mainStyle.common_slide}`}>
       <Slider {...settings}>
         <div className={mainStyle.hot_prf_list}>
-          <a href="#">
+          <Link to="/cultureinfo/detail">
             <img src="https://images.unsplash.com/photo-1545264835-3e14e4dae383?q=80&w=2548&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="hot performance poster"/>
             <div className={mainStyle.hot_prf_txt}>
               <p className={mainStyle.hot_tit}>서양 미술 800년展</p>
               <p className={mainStyle.hot_place}>더 현대 서울 ALT.1</p>
               <p className={mainStyle.hot_period}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
             </div>
-          </a>
+          </Link>
         </div>
         <div className={mainStyle.hot_prf_list}>
-          <a href="#">
+          <Link to="/cultureinfo/detail">
             <img src="https://images.unsplash.com/photo-1571847140471-1d7766e825ea?q=80&w=3866&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="hot performance poster"/>
             <div className={mainStyle.hot_prf_txt}>
               <p className={mainStyle.hot_tit}>서양 미술 800년展</p>
               <p className={mainStyle.hot_place}>더 현대 서울 ALT.1</p>
               <p className={mainStyle.hot_period}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
             </div>
-          </a>
+          </Link>
         </div>
         <div className={mainStyle.hot_prf_list}>
-          <a href="#">
+          <Link to="/cultureinfo/detail">
             <img src="https://images.unsplash.com/photo-1625062833789-b0273c8a3f58?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MjB8fGNvbmNlcnQlMjBwb3N0ZXJ8ZW58MHx8MHx8fDA%3D" alt="hot performance poster"/>
             <div className={mainStyle.hot_prf_txt}>
               <p className={mainStyle.hot_tit}>서양 미술 800년展</p>
               <p className={mainStyle.hot_place}>더 현대 서울 ALT.1</p>
               <p className={mainStyle.hot_period}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
             </div>
-          </a>
+          </Link>
         </div>     
         <div className={mainStyle.hot_prf_list}>
-          <a href="#">
+          <Link to="/cultureinfo/detail">
             <img src="https://images.unsplash.com/photo-1569949237615-e2defbeb5d0a?q=80&w=1960&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="hot performance poster"/>
             <div className={mainStyle.hot_prf_txt}>
               <p className={mainStyle.hot_tit}>서양 미술 800년展</p>
               <p className={mainStyle.hot_place}>더 현대 서울 ALT.1</p>
               <p className={mainStyle.hot_period}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
             </div>
-          </a>
+          </Link>
         </div>     
         <div className={mainStyle.hot_prf_list}>
-          <a href="#">
+          <Link to="/cultureinfo/detail">
             <img src="https://images.unsplash.com/photo-1497911270199-1c552ee64aa4?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MzF8fGNvbmNlcnQlMjBwb3N0ZXJ8ZW58MHx8MHx8fDA%3D" alt="hot performance poster"/>
             <div className={mainStyle.hot_prf_txt}>
               <p className={mainStyle.hot_tit}>서양 미술 800년展</p>
               <p className={mainStyle.hot_place}>더 현대 서울 ALT.1</p>
               <p className={mainStyle.hot_period}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
             </div>
-          </a>
+          </Link>
         </div>     
       </Slider>
     </div>

--- a/src/components/main/TopBanner.js
+++ b/src/components/main/TopBanner.js
@@ -2,6 +2,7 @@ import '../../styles/slick-theme.css';
 import '../../styles/slick.css';
 import mainStyle from '../../pages/main/Main.module.css';
 import Slider from "react-slick";
+import { Link } from 'react-router-dom';
 
 export default function TopBanner() {
   const settings = {
@@ -21,29 +22,29 @@ export default function TopBanner() {
     <div className={`slider-container ${mainStyle.top_banner_box}`}>
       <Slider {...settings}>
         <div className={mainStyle.centerList}>
-          <a href='#'>
+          <Link to="/cultureinfo/detail">
             <img src="https://images.unsplash.com/photo-1567942712661-82b9b407abbf?q=80&w=3474&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="top banner"/>
-          </a>
+          </Link>
         </div>
         <div className={mainStyle.centerList}>
-          <a href='#'>
+          <Link to="/cultureinfo/detail">
             <img src="https://images.unsplash.com/photo-1562329265-95a6d7a83440?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Nnx8YnJvYWR3YXklMjBtdXNpY2FsfGVufDB8fDB8fHww" alt="top banner"/>
-          </a>
+          </Link>
         </div>
         <div className={mainStyle.centerList}>
-          <a href='#'>
+          <Link to="/cultureinfo/detail">
             <img src="https://images.unsplash.com/photo-1545264835-3e14e4dae383?q=80&w=2548&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="top banner"/>
-          </a>
+          </Link>
         </div>
         <div className={mainStyle.centerList}>
-          <a href='#'>
+          <Link to="/cultureinfo/detail">
             <img src="https://images.unsplash.com/photo-1584448097764-374f81551427?q=80&w=2196&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="top banner"/>
-          </a>
+          </Link>
         </div>
         <div className={mainStyle.centerList}>
-          <a href='#'>
+          <Link to="/cultureinfo/detail">
             <img src="https://images.unsplash.com/photo-1563841930606-67e2bce48b78?q=80&w=2054&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="top banner"/>
-          </a>
+          </Link>
         </div>      
       </Slider>
     </div>

--- a/src/pages/main/Main.js
+++ b/src/pages/main/Main.js
@@ -3,8 +3,11 @@ import TopBanner from '../../components/main/TopBanner';
 import HotBanner from '../../components/main/HotBanner';
 import EarlyBanner from '../../components/main/EarlyBanner';
 import { useEffect } from "react";
+import { useNavigate } from 'react-router-dom';
 
 export default function Main() {
+  
+  const navigate = useNavigate();
 
   // 스크롤시 Header 색상 변경 
   useEffect(
@@ -40,7 +43,7 @@ export default function Main() {
           <div className={mainStyles.hot_prf_sec}>
             <div className={`${mainStyles.tit_view_more} ${mainStyles.flex_center}`}>
               <p className={mainStyles.sec_tit}>HOT 전시/공연 정보</p>
-              <span className={`${mainStyles.view_more_btn} ${mainStyles.flex_center}`}>더보기 <img src={`${process.env.PUBLIC_URL}/images/commons/icon_arrow_right_white.png`} alt="arrow left direction icon"/></span>
+              <span className={`${mainStyles.view_more_btn} ${mainStyles.flex_center}`} onClick={() => navigate("/cultureinfo")}>더보기 <img src={`${process.env.PUBLIC_URL}/images/commons/icon_arrow_right_white.png`} alt="arrow left direction icon"/></span>
             </div>
             {HotBanner()}
           </div>
@@ -50,7 +53,7 @@ export default function Main() {
             <div className={mainStyles.early_sec}>
               <div className={`${mainStyles.tit_view_more} ${mainStyles.flex_center}`}>
                 <p className={mainStyles.sec_tit}>얼리버드</p>
-                <span className={`${mainStyles.view_more_btn} ${mainStyles.flex_center}`}>더보기 <img src={`${process.env.PUBLIC_URL}/images/commons/icon_arrow_right_white.png`} alt="arrow left direction icon"/></span>
+                <span className={`${mainStyles.view_more_btn} ${mainStyles.flex_center}`} onClick={() => navigate("/cultureinfo")}>더보기 <img src={`${process.env.PUBLIC_URL}/images/commons/icon_arrow_right_white.png`} alt="arrow left direction icon"/></span>
               </div>
               <div className={mainStyles.early_slide_box}>
                 {EarlyBanner()}
@@ -64,7 +67,7 @@ export default function Main() {
             <div className={mainStyles.honeypot_sec}>
               <div className={`${mainStyles.tit_view_more} ${mainStyles.flex_center}`}>
                 <p className={mainStyles.sec_tit}>허니팟</p>
-                <span className={`${mainStyles.view_more_btn} ${mainStyles.flex_center}`}>더보기 <img src={`${process.env.PUBLIC_URL}/images/commons/icon_arrow_right_white.png`} alt="arrow right direction icon"/></span>
+                <span className={`${mainStyles.view_more_btn} ${mainStyles.flex_center}`} onClick={() => navigate("/honey")}>더보기 <img src={`${process.env.PUBLIC_URL}/images/commons/icon_arrow_right_white.png`} alt="arrow right direction icon"/></span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[FEATURE][MAIN]

### 💡 작업동기
- 메인 페이지 레이아웃 작업

### 🔑 주요 변경사항
- 1. 슬라이드 및 페이지 내 공연/전시 정보 리스트 아이템 클릭시, 공연/전시 상세 페이지로 연결(*API 연결 작업은 되어 있지않아 샘플 상세 페이지에 일괄 연결한 상태)
- 2. '더보기' 버튼 클릭시, 공연/전시 정보 메인 페이지로 이동

### 🏞 스크린샷
![screencapture-localhost-3000-main-2024-06-23-03_10_08](https://github.com/S-O-O-P/S-O-O-P-React/assets/73331620/fe44258a-89c8-47b3-8ac1-0d24559e96c2)

### 관련 이슈
- #33 

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
