### PR TITLE
[FEATURE][CULTUREINFO][EARLYBIRD]얼리버드 공연/전시 정보 REST Api 호출 및 연결하기

### DIFF
--- a/src/apis/CultureApi.js
+++ b/src/apis/CultureApi.js
@@ -24,7 +24,7 @@ export default function CultureApi({ setData }) {
         const parser = new DOMParser(); // XML 문자열을 파싱하기 위해 DOMParser 객체를 생성
         const xmlDom = parser.parseFromString(xmlText, 'application/xml'); // XML 문자열을 XML DOM 객체로 변환
         const jsonData = xmlToJson(xmlDom); // XML 데이터를 JSON 형식으로 변환
-        // setData(jsonData.response.msgBody[0]); // App.js에서 전달받은 setData 함수를 호출하여 데이터 설정
+        setData(jsonData.response.msgBody[0]); // App.js에서 전달받은 setData 함수를 호출하여 데이터 설정
         // console.log("from CultureApi : "+jsonData.response.msgBody[0]);
       } else {
         // 오류 처리

--- a/src/apis/cultureInfo/EarlyBirdApi.js
+++ b/src/apis/cultureInfo/EarlyBirdApi.js
@@ -5,7 +5,7 @@ export default function EarlyBirdInfoApi({setEarlyBirdInfo} = null, apiName, ear
   // 얼리버드 공연/전시 정보 모두 호출
   const selectAllEarlyBirdInfo = () => {
     // axios.get('http://localhost:8080/cultureinfo/early')
-    axios.get('/local-api/cultureinfo/early')
+    axios.get('/local-api/early')
       .then(response => {
         console.log('API Response All:', response.data); // 디버깅을 위한 로그
         setEarlyBirdInfo(response.data.earlyBirdList || []); // EarlyBirdInfo가 null일 경우 빈 배열로 설정
@@ -17,7 +17,7 @@ export default function EarlyBirdInfoApi({setEarlyBirdInfo} = null, apiName, ear
 
   // 얼리버드 공연/전시 상세 정보 호출
   const selectDetailEarlyBirdInfo = (earlyCode) => {
-    axios.get('/local-api/cultureinfo/early/'+earlyCode)
+    axios.get('/local-api/early/'+earlyCode)
       .then(response => {
         console.log('API Response detail:', response.data); // 디버깅을 위한 로그
         setEarlyBirdInfo(response.data.foundEarlyInfo || {}); // EarlyBirdInfo가 null일 경우 빈 객체로 설정        

--- a/src/components/cultureInfo/CardType.js
+++ b/src/components/cultureInfo/CardType.js
@@ -2,9 +2,10 @@ import { Link } from 'react-router-dom';
 import styles from '../../pages/cultureInfo/CultureInfo.module.css';
 import LoadingSpinner from '../commons/Loading';
 
-export default function CardType({cultureList, detailDataList}){
+export default function CardType({cultureList, detailDataList, earlyCheck}){
   console.log('Culture List:', cultureList);
   console.log('Detail Data List:', detailDataList);
+  console.log('earlyCheck:', earlyCheck);
 
   // 데이터가 로딩 중일 때 처리
   // if (!cultureList || !cultureList.perforList || !detailDataList) {
@@ -20,9 +21,9 @@ export default function CardType({cultureList, detailDataList}){
             // 공연 / 전시 start/endDate
             const convertDateFormat = (stringDate, type) => {
               let dateFormat = "";
-              const year = stringDate.slice(0, 4);
-              const month = stringDate.slice(4, 6);
-              const day = stringDate.slice(6);
+              const year = stringDate?.slice(0, 4);
+              const month = stringDate?.slice(4, 6);
+              const day = stringDate?.slice(6);
               if(type == "rest"){
                 dateFormat = new Date(year+"-"+month+"-"+day); // 날짜 표시 형식
               } else{
@@ -31,34 +32,61 @@ export default function CardType({cultureList, detailDataList}){
               return dateFormat;
             }
 
-            const title = item.title.replaceAll('&lt;',`<`).replaceAll('&gt;',`>`).replaceAll("&#39;","'"); // 제목          
-            if(parseInt(convertDateFormat(item.endDate, "rest") - today) < 7){
-              console.log("남은 공연/전시 기간 : " + parseInt((convertDateFormat(item.endDate, "rest") - today) / 86400000));              
+            // 날짜 형식 변경
+            function formatDate(date) {
+              var writtenDate = new Date(date),
+                month = '' + (writtenDate?.getMonth() + 1),
+                day = '' + writtenDate?.getDate(),
+                year = writtenDate?.getFullYear();
+
+              if (month.length < 2) 
+                month = '0' + month;
+              if (day.length < 2) 
+                day = '0' + day;
+
+              return [year, month, day].join('.');
             }
+
+            // 얼리버드 공연/전시 가격 1000단위 ,
+            const convertPriceFormat = (dPrice) => {
+              if (!dPrice && dPrice !== 0) { // dPrice가 유효하지 않은 경우를 처리
+                return "가격 정보 업데이트중"; // 기본 값 반환
+              }
+              const endPrice = (dPrice?.toString()).slice(-3);
+              const startPirce = (dPrice?.toString()).slice(0, -3);
+              return startPirce+','+endPrice;
+            }
+
+            const title = earlyCheck ? item.ebTitle.replaceAll('&lt;',`<`).replaceAll('&gt;',`>`).replaceAll("&#39;","'") :  item.title.replaceAll('&lt;',`<`).replaceAll('&gt;',`>`).replaceAll("&#39;","'"); // 제목          
+            
 
             // seq에 해당하는 detailData 가져오기
             const detailData = detailDataList[item.seq];
-            // console.log("Detail data for seq ", item.seq, ": ", detailData);
 
             // detailData가 존재하고 price 속성이 있을 때 가격 표시
-            const price = detailData && detailData.price ? detailData.price : "가격 정보 없음";
+            const price = earlyCheck ? convertPriceFormat(item?.discountPrice) : detailData && detailData.price ? detailData.price : "가격 정보 없음";
             // const detailData = detailDataList[item.seq]; // seq(공연/전시 코드)에 따른 상세 정보
             // console.log("price from cardtype : " + JSON.stringify(detailData));
-            const earlyCheck = false; // 얼리버드 여부 - false로 초기화
+            const discountRate = earlyCheck ? (item?.discountPrice / item?.regularPrice * 100) : null;
+            console.log("discount Rate : " + item?.discountPrice);
+            console.log("discount Rate : " + typeof item?.discountPrice);
+            console.log("discount Rate : " + item?.regularPrice);
+            console.log("discount Rate : " + (item.discountPrice / item.regularPrice * 100));
+            console.log("discount Rate : " + (item.discountPrice / item.regularPrice * 100));
             
             return(
               <li key={index}>
-                <Link to={`/cultureinfo/detail/${item.seq}`}>
+                <Link to={earlyCheck ? `/cultureinfo/detail/${item.earlyBirdCode}` : `/cultureinfo/detail/${item.seq}`}  state={earlyCheck ? { earlyCheck: true } : {earlyCheck : false}}>
                   <div className={styles.culture_img}>
-                  <img src={item.thumbnail} alt={`${title} thumbnail`}/>
-                    {(parseInt((convertDateFormat(item.endDate, "rest") - today) / 86400000) < 7) ? <span className={styles.culture_mark}>마감임박</span> : null}
+                  <img src={earlyCheck ? item.poster : item.thumbnail} alt={`${title} thumbnail`}/>
+                    {earlyCheck ? ((parseInt((new Date(item.saleEndDate) - today) / 86400000) < 7) ? <span className={styles.culture_mark}>마감임박</span> : null) : (parseInt((convertDateFormat(item.endDate, "rest") - today) / 86400000) < 7) ? <span className={styles.culture_mark}>마감임박</span> : null}
                   </div>
                   <div className={styles.culture_item_txt}>
                     <p className={styles.culture_tit}>{title}</p>
-                    <p className={styles.culture_date}>{convertDateFormat(item.startDate, null)} ~ {convertDateFormat(item.endDate, null)}</p>
+                    {earlyCheck ? <p className={styles.culture_date}>{formatDate(item.saleStartDate)} ~ {formatDate(item.saleEndDate)}</p> : <p className={styles.culture_date}>{convertDateFormat(item.startDate, null)} ~ {convertDateFormat(item.endDate, null)}</p>}
                     <p className={styles.early_end}></p>
                     <p className={styles.culture_price}>
-                      { earlyCheck ? <span className={styles.sale_rate}>30%</span> : null} {price}
+                      { earlyCheck ? <span className={styles.sale_rate}>{discountRate}</span> : null} {price}
                     </p>
                   </div>
                 </Link>

--- a/src/components/cultureInfo/EarlySlide.js
+++ b/src/components/cultureInfo/EarlySlide.js
@@ -32,38 +32,30 @@ export default function EarlySlide({earlyBirdInfo}) {
       const endDate = new Date(targetDate);
       const timeRemaining = endDate - now;
    
-      if (timeRemaining <= 0) {
-        const timerText = document.querySelectorAll(`.${styles.time_left}`);
-        
-        timerText.forEach((timer) => {
-          timer.textContent = '종료';
-        })
+      if (timeRemaining <= 0) {                
         console.log("종료");
-          return;
+          return "종료";
       }
    
       const days = Math.floor(timeRemaining / (1000 * 60 * 60 * 24));
       const hours = Math.floor((timeRemaining % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
       const minutes = Math.floor((timeRemaining % (1000 * 60 * 60)) / (1000 * 60));
-      const seconds = Math.floor((timeRemaining % (1000 * 60)) / 1000);
-   
-      // document.querySelector(`.${styles.time_left}`).textContent 
-      //   = `${days}일 ${hours}시간 ${minutes}분 ${seconds}초`;
-      const timerText = document.querySelectorAll(`.${styles.time_left}`);      
-        timerText.forEach((timer) => {
-          timer.textContent = `${days}일 ${hours}시간 ${minutes}분 ${seconds}초`;
-        })
-      console.log(`${days}일 ${hours}시간 ${minutes}분 ${seconds}초`);
+
+      return `${days}일 ${hours}시간 ${minutes}분`;
+      // const seconds = Math.floor((timeRemaining % (1000 * 60)) / 1000);
+
+      // const timerText = document.querySelectorAll(`.${styles.time_left}`);      
+        // timerText.forEach((timer) => {
+        //   timer.textContent = `${days}일 ${hours}시간 ${minutes}분`;
+        //   // timer.textContent = `${days}일 ${hours}시간 ${minutes}분 ${seconds}초`;
+        // })
+      // console.log(`${days}일 ${hours}시간 ${minutes}분 ${seconds}초`);
   }
    
   // 타겟 날짜 설정 (예: 2023년 12월 31일 23:59:59)
   // const targetDate = new Date('2023-12-31T23:59:59').getTime();
    
-  // 1초마다 업데이트
-  const timerSet = (time) => {
-    setInterval(() => {
-    timer(time);
-  }, 1000);}
+ 
 
   const settings = {
     infinite: true,
@@ -82,8 +74,6 @@ export default function EarlySlide({earlyBirdInfo}) {
     <div className={`slider-container ${styles.common_slide}`}>
       <Slider {...settings}>
       {earlyBirdInfo ? earlyBirdInfo.map((item, index) => {
-          // const { saleEndDate, poster, ebTitle, earlyBirdCode } = item;
-          // if (!saleEndDate || !poster || !ebTitle) return null;
           // 날짜 형식 변경
           function formatDate(date) {
             var writtenDate = new Date(date),
@@ -99,18 +89,20 @@ export default function EarlySlide({earlyBirdInfo}) {
             return [year, month, day].join('.');
           }
 
-          timerSet(new Date(item.saleEndDate).getTime());
-          // 공연 / 전시 start/endDate
-          
+           // 1초마다 업데이트
+          // const timerSet = (time) => {
+          //   setInterval(() => {
+          //   timer(time);
+          // }, 1000);}
 
-          const title = item?.ebTitle.replaceAll('&lt;',`<`).replaceAll('&gt;',`>`).replaceAll("&#39;","'"); // 제목          
-          // if(parseInt(convertDateFormat(item?.endDate, "rest") - today) < 7){
-          //   console.log("남은 공연/전시 기간 : " + parseInt((convertDateFormat(item?.endDate, "rest") - today) / 86400000));              
-          // }
+          // timerSet(new Date(item.saleEndDate).getTime());
+          const targetTime = new Date(item.saleEndDate).getTime();
+
+          const title = item?.ebTitle.replaceAll('&lt;',`<`).replaceAll('&gt;',`>`).replaceAll("&#39;","'"); // 
 
           return(
             <div className={styles.early_slide_list} key={index}>
-              <Link to={`/cultureinfo/detail/${item.earlyBirdCode}`} className={styles.flex_start}>
+              <Link to={`/cultureinfo/detail/${item.earlyBirdCode}`} state={{ earlyCheck: true }} className={styles.flex_start}>
                 <div className={styles.early_img}>
                   <img src={item.poster} alt="early bird info"/>
                 </div>
@@ -119,8 +111,7 @@ export default function EarlySlide({earlyBirdInfo}) {
                   <p className={styles.early_date}>{formatDate(item.saleStartDate, null)}&nbsp;~&nbsp;{formatDate(item.saleEndDate, null)}</p>
                   <p className={styles.early_place}>{item.place}</p>
                   <span className={styles.left_time_mark}>남은시간</span>
-                  <p className={styles.time_left}></p>
-                  {/* <span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span> */}
+                  <p className={styles.time_left}>{timer(targetTime)}</p>
                   <p className={styles.early_end_date}>얼리버드 : {formatDate(item.saleEndDate, null)}&nbsp;<span>24:00</span>까지</p>
                 </div>
               </Link>
@@ -131,79 +122,3 @@ export default function EarlySlide({earlyBirdInfo}) {
     </div>
   );
 }
-
-{/* <div className={styles.early_slide_list}>
-          <Link to="/cultureinfo/detail" className={styles.flex_start}>
-            <div className={styles.early_img}>
-              <img src="https://images.unsplash.com/photo-1514525253161-7a46d19cd819?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mzd8fGNvbmNlcnQlMjBwb3N0ZXJ8ZW58MHx8MHx8fDA%3D" alt="early bird info"/>
-            </div>
-            <div className={styles.early_txt_box}>
-              <p className={styles.early_tit}>서양 미술 800년展</p>
-              <p className={styles.early_date}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-              <p className={styles.early_place}>더현대서울 6층 ALT.1</p>
-              <span className={styles.left_time_mark}>남은시간</span>
-              <p className={styles.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
-              <p className={styles.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
-            </div>
-          </Link>
-        </div>
-        <div className={styles.early_slide_list}>
-          <Link to="/cultureinfo/detail" className={styles.flex_start}>
-            <div className={styles.early_img}>
-              <img src="https://images.unsplash.com/photo-1598387180437-80388ae0df12?q=80&w=3552&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="early bird info"/>
-            </div>
-            <div className={styles.early_txt_box}>
-              <p className={styles.early_tit}>서양 미술 800년展</p>
-              <p className={styles.early_date}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-              <p className={styles.early_place}>더현대서울 6층 ALT.1</p>
-              <span className={styles.left_time_mark}>남은시간</span>
-              <p className={styles.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
-              <p className={styles.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
-            </div>
-          </Link>
-        </div>
-        <div className={styles.early_slide_list}>
-          <Link to="/cultureinfo/detail" className={styles.flex_start}>
-            <div className={styles.early_img}>
-              <img src="https://plus.unsplash.com/premium_photo-1695636587294-5e7eba3e3b43?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8ZmVzdGl2YWwlMjBwb3N0ZXJ8ZW58MHx8MHx8fDA%3D" alt="early bird info"/>
-            </div>
-            <div className={styles.early_txt_box}>
-              <p className={styles.early_tit}>서양 미술 800년展</p>
-              <p className={styles.early_date}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-              <p className={styles.early_place}>더현대서울 6층 ALT.1</p>
-              <span className={styles.left_time_mark}>남은시간</span>
-              <p className={styles.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
-              <p className={styles.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
-            </div>
-          </Link>
-        </div>
-        <div className={styles.early_slide_list}>
-          <Link to="/cultureinfo/detail" className={styles.flex_start}>
-            <div className={styles.early_img}>
-              <img src="https://images.unsplash.com/photo-1580130544401-347c796dceec?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NHx8ZXhoaWJpdGlvbiUyMHBvc3RlcnxlbnwwfHwwfHx8MA%3D%3D" alt="early bird info"/>
-            </div>
-            <div className={styles.early_txt_box}>
-              <p className={styles.early_tit}>서양 미술 800년展</p>
-              <p className={styles.early_date}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-              <p className={styles.early_place}>더현대서울 6층 ALT.1</p>
-              <span className={styles.left_time_mark}>남은시간</span>
-              <p className={styles.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
-              <p className={styles.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
-            </div>
-          </Link>
-        </div>
-        <div className={styles.early_slide_list}>
-          <Link to="/cultureinfo/detail" className={styles.flex_start}>
-            <div className={styles.early_img}>
-              <img src="https://images.unsplash.com/photo-1530263131525-1c1d26feaa60?q=80&w=3542&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="early bird info"/>
-            </div>
-            <div className={styles.early_txt_box}>
-              <p className={styles.early_tit}>서양 미술 800년展</p>
-              <p className={styles.early_date}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-              <p className={styles.early_place}>더현대서울 6층 ALT.1</p>
-              <span className={styles.left_time_mark}>남은시간</span>
-              <p className={styles.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
-              <p className={styles.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
-            </div>
-          </Link>
-        </div> */}

--- a/src/components/cultureInfo/TableType.js
+++ b/src/components/cultureInfo/TableType.js
@@ -2,7 +2,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import styles from '../../pages/cultureInfo/CultureInfo.module.css';
 import LoadingSpinner from '../commons/Loading';
 
-export default function TableType({cultureList, detailDataList}){
+export default function TableType({cultureList, detailDataList, earlyCheck}){
   // 데이터가 로딩 중일 때 처리
   const navigate = useNavigate();
   const today = new Date();
@@ -26,9 +26,9 @@ export default function TableType({cultureList, detailDataList}){
             // 공연 / 전시 start/endDate
             const convertDateFormat = (stringDate, type) => {
               let dateFormat = "";
-              const year = stringDate.slice(0, 4);
-              const month = stringDate.slice(4, 6);
-              const day = stringDate.slice(6);
+              const year = stringDate?.slice(0, 4);
+              const month = stringDate?.slice(4, 6);
+              const day = stringDate?.slice(6);
               if(type == "rest"){
                 dateFormat = new Date(year+"-"+month+"-"+day); // 날짜 표시 형식
               } else{
@@ -37,7 +37,22 @@ export default function TableType({cultureList, detailDataList}){
               return dateFormat;
             }
 
-            const title = item.title.replaceAll('&lt;',`<`).replaceAll('&gt;',`>`).replaceAll("&#39;","'"); // 제목  
+            // 날짜 형식 변경
+            function formatDate(date) {
+              var writtenDate = new Date(date),
+                month = '' + (writtenDate?.getMonth() + 1),
+                day = '' + writtenDate?.getDate(),
+                year = writtenDate?.getFullYear();
+
+              if (month.length < 2) 
+                month = '0' + month;
+              if (day.length < 2) 
+                day = '0' + day;
+
+              return [year, month, day].join('.');
+            }
+
+            const title = earlyCheck ? item.ebTitle.replaceAll('&lt;',`<`).replaceAll('&gt;',`>`).replaceAll("&#39;","'") :  item.title.replaceAll('&lt;',`<`).replaceAll('&gt;',`>`).replaceAll("&#39;","'"); // 제목  
 
             //item.realmName
             const category = (realName) => {
@@ -51,19 +66,32 @@ export default function TableType({cultureList, detailDataList}){
               }
             }
 
+            // 카테고리 string으로 변환
+            const categoryString = (category) => {
+              let categoryString = "";
+              switch(category){
+                case(1) : categoryString = "팝업"; break;
+                case(2) : categoryString = "공연"; break;
+                case(3) : categoryString = "행사/축제"; break;
+                case(4) : categoryString = "전시회"; break;
+                case(5) : categoryString = "뮤지컬"; break;
+              }
+              return categoryString;
+            }
+
             // seq에 해당하는 detailData 가져오기
             const detailData = detailDataList[item.seq];
             // console.log("Detail data for seq ", item.seq, ": ", detailData);
 
             // detailData가 존재하고 price 속성이 있을 때 가격 표시
-            const price = detailData && detailData.price ? detailData.price : "가격 정보 없음";
+            const price = earlyCheck ? item.discountPrice : detailData && detailData.price ? detailData.price : "가격 정보 없음";
             
             return(            
-                <tr onClick={() => navigate(`/cultureinfo/detail/${item.seq}`)} key={index}>
-                  <td>{category(item.realmName)}</td>
+                <tr onClick={() => navigate( earlyCheck ? `/cultureinfo/detail/${item.earlyBirdCode}` : `/cultureinfo/detail/${item.seq}`)} key={index}  state={{ earlyCheck: true }}>
+                  <td>{earlyCheck ? categoryString(earlyCheck.interestCode) : category(item.realmName)}</td>
                   <td>{title}</td>
                   <td>{price}</td>
-                  <td>{convertDateFormat(item.startDate, null)} ~ {convertDateFormat(item.endDate, null)}</td>
+                  <td>{earlyCheck ? <p className={styles.culture_date}>{formatDate(item.saleStartDate)} ~ {formatDate(item.saleEndDate)}</p> : <p className={styles.culture_date}>{convertDateFormat(item.startDate)} ~ {convertDateFormat(item.endDate)}</p>}</td>
                 </tr>
               
             );          
@@ -73,33 +101,3 @@ export default function TableType({cultureList, detailDataList}){
       </>
   );
 }
-{/* <table>
-                <thead>
-                  <tr>
-                    <th>구분</th>
-                    <th>제목</th>
-                    <th>가격</th>
-                    <th>일정</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr onClick={() => navigate("/cultureinfo/detail")}>
-                    <td>뮤지컬</td>
-                    <td>뮤지컬 〈디어 에반 핸슨〉 - 부산 (Dear Evan Hansen)</td>
-                    <td>70,000 ~ 160,000원</td>
-                    <td>2024.08.20~2024.08.31</td>
-                  </tr>
-                  <tr onClick={() => navigate("/cultureinfo/detail")}>
-                    <td>팝업스토어</td>
-                    <td>뮤지컬 〈디어 에반 핸슨〉 - 부산 (Dear Evan Hansen)</td>
-                    <td>70,000 ~ 160,000원</td>
-                    <td>2024.08.20~2024.08.31</td>
-                  </tr>
-                  <tr onClick={() => navigate("/cultureinfo/detail")}>
-                    <td>팝업스토어</td>
-                    <td><p>뮤지컬 〈디어 에반 핸슨〉 - 부산 (Dear Evan Hansen)asdfasdfasdfasdfasdfagdfgsdfgsdfgsdfgsdfgsdfgdfgdfgdfgsfggsf</p></td>
-                    <td>70,000 ~ 160,000원</td>
-                    <td>2024.08.20~2024.08.31</td>
-                  </tr>
-                </tbody>
-              </table> */}

--- a/src/pages/cultureInfo/CultureDetail.js
+++ b/src/pages/cultureInfo/CultureDetail.js
@@ -1,41 +1,60 @@
 import { useEffect, useState } from "react";
 import styles from "./CultureInfo.module.css";
-import { useParams } from "react-router-dom";
+import "../../components/honeypot/HoneypotList.css";
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import EarlyBirdInfoApi from "../../apis/cultureInfo/EarlyBirdApi";
+import HoneypotListApi from "../../apis/honeypot/HoneypotListApi";
 
 export default function CultureDetail(props) {
+  const {isEarly} = props;
   const [detailData, setDetailData] = useState(null); //상세 정보 저장
   const [earlyBirdInfo, setEarlyBirdInfo] = useState(null); // 얼리버드 상세 정보 저장
+  const [honeypots, setHoneypots] = useState([]);
+  const [filteredHoneypots, setFilteredHoneypots] = useState([]); // 필터링된 허니팟 데이터
   const { seq } = useParams({}); // seq 코드 param으로 가져오기
   const [early, setEarly] = useState(false); // 얼리버드 여부 - false로 초기화
   const [detailInfo, setDetailInfo] = useState(""); // 상세 내용
+  const navigate = useNavigate();
+  const location = useLocation();
+  
 
   useEffect(
     () => {
-      if(seq){
+      if(location.state && seq){
+        const {earlyCheck} = location.state;
         //얼리버드 공연/전시 상세 조회 api 호출
         EarlyBirdInfoApi({setEarlyBirdInfo}, "detail", seq);
         console.log("events detail : ",earlyBirdInfo);
+        if(earlyCheck === true){
+          setEarly(true);
+        }        
       }
     },[seq]
   );
 
   useEffect(
     () => {
-      if (earlyBirdInfo && Object.keys(earlyBirdInfo).length > 0) {
+      if (earlyBirdInfo && Object.keys(earlyBirdInfo).length > 0) { // 얼리버드 공연/전시 정보가 존재한다면
         // setDetailInfo(events?.ebContent);
-        setDetailInfo((earlyBirdInfo?.ebContent).replaceAll("<br>", `\n`));
+        setDetailInfo((earlyBirdInfo?.ebContent).replaceAll("<br>", `\n`)); // 상세 정보 줄바꿈 변경
       }
     },[earlyBirdInfo]
   );
 
   useEffect(() => {
-    if (props.detailDataList) {
-      setDetailData(props.detailDataList[seq]);
+    if (props.detailDataList) { // 공연/전시 상세 데이터 리스트가 정상적으로 전달되었다면
+      setDetailData(props.detailDataList[seq]); // seq번호에 해당하는 상세 정보 state 설정
     }
     console.log("공연 / 전시 상세 정보 : " + JSON.stringify(detailData?.title));
     console.log(seq);
   }, [detailData]);
+
+  useEffect(() => {
+    if(seq){
+      HoneypotListApi({setHoneypots}, {setFilteredHoneypots});
+      console.log("honeypots",honeypots);
+    }
+  }, [seq]);
 
   useEffect(
     () => {
@@ -85,42 +104,74 @@ export default function CultureDetail(props) {
     return dateFormat;
   }
 
+  // 날짜 형식 변경
+  function formatDate(date) {
+    var writtenDate = new Date(date),
+      month = '' + (writtenDate?.getMonth() + 1),
+      day = '' + writtenDate?.getDate(),
+      year = writtenDate?.getFullYear();
+
+    if (month.length < 2) 
+      month = '0' + month;
+    if (day.length < 2) 
+      day = '0' + day;
+
+    return [year, month, day].join('.');
+  }
+  
+  // 얼리버드 공연/전시 가격 1000단위 ,
+  const convertPriceFormat = (dPrice) => {
+    if (!dPrice && dPrice !== 0) { // dPrice가 유효하지 않은 경우를 처리
+      return "가격 정보를 업데이트중입니다.\n잠시만 기다려주세요."; // 기본 값 반환
+    }
+    const endPrice = (dPrice?.toString()).slice(-3);
+    const startPirce = (dPrice?.toString()).slice(0, -3);
+    return startPirce+','+endPrice;
+  }
+
   return (
     <>
       {/* contents */}
       <div className={styles.contents_cont}>
         <div className={styles.detail_sec_box}>
           <div className={styles.detail_sec}>
-            <p className={`${styles.sec_tit} ${styles.left}`}>{detailData?.title.replaceAll('&lt;', `<`).replaceAll('&gt;', `>`).replaceAll("&#39;", "'")}</p>
+            <p className={`${styles.sec_tit} ${styles.left}`}>{early == false ? detailData?.title.replaceAll('&lt;', `<`).replaceAll('&gt;', `>`).replaceAll("&#39;", "'") : earlyBirdInfo?.ebTitle}</p>
             <div className={`${styles.detail_summary} ${styles.flex_between}`}>
-              <div className={styles.detail_img}><img src={detailData?.imgUrl} alt="detail page" /></div>
+              <div className={styles.detail_img}><img src={early == false ? detailData?.imgUrl : earlyBirdInfo?.poster} alt="detail page" /></div>
               <div className={styles.summary_txt_box}>
                 <ul>
-                  <li className={styles.flex_start}><p className={styles.detail_item_tit}>장소</p><p>{detailData?.place}</p></li>
-                  <li className={styles.flex_start}><p className={styles.detail_item_tit}>기간</p><p>{convertDateFormat(detailData?.startDate, null)} ~ {convertDateFormat(detailData?.endDate, null)}</p></li>
-                  <li className={styles.flex_start}><p className={styles.detail_item_tit}>관람 연령</p><p>전체관람가</p></li>
+                  <li className={styles.flex_start}><p className={styles.detail_item_tit}>장소</p><p>{early == false ? detailData?.place : earlyBirdInfo?.place}</p></li>
+                  <li className={styles.flex_start}><p className={styles.detail_item_tit}>{early == false ? "기간" : "예매 기간"}</p><p>{early == false ? convertDateFormat(detailData?.startDate, null) : formatDate(earlyBirdInfo?.usageStartDate)} ~ {early == false ? convertDateFormat(detailData?.endDate, null) : formatDate(earlyBirdInfo?.usageEndDate)}</p></li>
+                  {early != false ? <li className={styles.flex_start}><p className={styles.detail_item_tit}>사용 기한</p><p>{early == false ? convertDateFormat(detailData?.startDate, null) : formatDate(earlyBirdInfo?.usageStartDate)} ~ {early == false ? convertDateFormat(detailData?.endDate, null) : formatDate(earlyBirdInfo?.usageEndDate)}</p></li> : null}
+                  {early != false ? <li className={styles.flex_start}><p className={styles.detail_item_tit}>관람 연령</p><p>{earlyBirdInfo?.ageLimit}</p></li> : null}
+                  {early != false ? <li className={styles.flex_start}>
+                    <p className={styles.detail_item_tit}>얼리버드 가격</p>
+                    <div className={`${styles.price_list}  ${styles.earlyPrice}`}>
+                    <p className={`${styles.price} ${styles.adult}`}>{convertPriceFormat(earlyBirdInfo?.discountPrice)}원</p>
+                    </div>
+                  </li> : null}
                   <li className={styles.flex_start}>
                     <p className={styles.detail_item_tit}>일반 가격</p>
                     <div className={styles.price_list}>
-                      <p className={`${styles.price} ${styles.adult}`}>{detailData?.price}</p>
+                      {early == false ? <p className={`${styles.price} ${styles.adult}`}>{detailData?.price }</p> : <p className={`${styles.price} ${styles.adult}`}>{convertPriceFormat(earlyBirdInfo?.regularPrice)}원</p>}
                       {/* <p>성인<span className={`${styles.price} ${styles.adult}`}>15,000</span>원</p> */}
                       {/* <p>청소년/어린이 <span className={`${styles.price} ${styles.adult}`}>10,000</span>원</p> */}
                     </div>
-                  </li>
-                  {/* <li className={styles.flex_start}>
-                    <p className={styles.detail_item_tit}>얼리버드 가격</p>
-                    <div className={styles.price_list}>
-                      <p>성인<span className={`${styles.price} ${styles.adult}`}>9,900</span>원</p>
-                      <p>청소년/어린이<span className={`${styles.price} ${styles.adult}`}>7,900</span>원</p>
-                    </div>
-                  </li> */}
+                  </li>                  
                   <li className={styles.flex_start}>
-                    <p className={styles.detail_item_tit}>{early ? "예매처" : "공식 홈페이지"}</p>
-                    <div className={styles.price_list}>
-                      <p>{detailData?.place}</p>
-                      {detailData?.placeUrl !== null || detailData?.placeUrl !== "" || detailData?.placeUrl !== `[{}]` ? <a href={detailData?.placeUrl} target="_blank" className={styles.short_cut_btn}>바로가기</a> : <p>예매처 정보가 존재하지 않습니다.\n추후 업데이트 예정입니다.</p>}
+                    <p className={styles.detail_item_tit}>{early != false ? "예매처" : "공식 홈페이지"}</p>
 
+                    {early == false ? <div className={styles.price_list}>
+                      <p>{detailData?.place}</p>
+                      {detailData?.placeUrl != null || detailData?.placeUrl != "" ? <Link to={detailData?.placeUrl} target="_blank" className={styles.short_cut_btn}>바로가기</Link> : <p>공식 홈페이지 정보가 존재하지 않습니다.\n추후 업데이트 예정입니다.</p>}
+
+                    </div> 
+                    : 
+                    <div className={styles.price_list}>
+                      <p>{earlyBirdInfo?.place}</p>
+                      {earlyBirdInfo?.sellerLink != null || earlyBirdInfo?.sellerLink != "" ? <Link to={earlyBirdInfo?.sellerLink} target="_blank" className={styles.short_cut_btn}>바로가기</Link> : <p>예매처 정보가 존재하지 않습니다.\n추후 업데이트 예정입니다.</p>}
                     </div>
+                    }
                   </li>
                 </ul>
               </div>
@@ -138,33 +189,59 @@ export default function CultureDetail(props) {
               {/* 탭에 따른 내용 영역 */}
               <ul className={`${styles.detail_info_list} ${styles.flex_start}`}>
                 {/* 이용 및 상세 정보 */}
-                <li>
-                  {early ? 
-                  <>
-                    <p className={styles.info_tit}>전시/공연 정보</p>
-                    <p className={styles.info_description}>[관람시간］</p>
-                    <p className={styles.info_description}>- 월-목 10:30~20:00 금-일 10:30~20:30</p>
-                    <p className={styles.info_description}>- 매표 및 입장 관람 종료 1시간 전 마감 </p>
-                    <p className={styles.info_description}>*휴관일은 더현대 서울의 휴점일에 따라 변동이 있습니다.</p>
-                    <p className={styles.info_tit}>얼리버드 티켓 안내</p>
-                    <p className={styles.info_description}>얼리버드 할인 티켓 구매 기간 : <span>2024.07.01 ~ 2024.07.19(금)</span></p>
-                    <p className={styles.info_description}>얼리버드 할인 티켓 이용 기간 : <span>2024.08.05 ~ 2024.09.06(금)</span></p>
-                  </> : null}
+                <li>                  
                   <p className={styles.info_tit}>상세 정보</p>
-                  <div className={styles.detail_info_img}>
+                  {early == false ? <div className={styles.detail_info_img}>
                     <img src={detailData?.imgUrl} alt={`${detailData?.title} info`} />
                   </div>
+                  :
+                  <>
+                    <div className={styles.detailInfoText}>{detailInfo}</div>
+                    <div className={styles.detail_info_img}>
+                      <img src={earlyBirdInfo?.poster} alt={`${earlyBirdInfo?.ebTitle} info`} />
+                    </div>
+                  </>
+                  }
                 </li>
 
                 {/* 허니팟 정보 */}
                 <li>
                   {/* 등록된 허니팟이 없는 경우 - NULL */}
-                  <div className={styles.detail_null_box}>
+                  { !honeypots ? <div className={styles.detail_null_box}>
                     <img src={`${process.env.PUBLIC_URL}/images/commons/logo.png`} alt="null page" />
                     <p className={styles.null_txt}>아직 등록된 허니팟이 없어요</p>
                     <p className={styles.null_txt}>지금 바로 허니팟 호스트가 되어 주세요</p>
                     <span className={styles.hosting_btn}>허니팟 호스팅</span>
+                  </div> 
+                  : 
+                  <div className="honeypot-list-container">
+                    {filteredHoneypots.map((honeypot, index) => (
+                    <div key={index} className="one-honeypot-index"
+                      onClick={ () => {navigate(`/honeypot/detail/${honeypot?.honeypotCode}`)}}>
+                        <div className="honeypot-index-poster">
+                          <img src={honeypot.poster} alt="포스터이미지" />
+                          <hr className="honeypot-dashed" />
+                        </div>
+                        <div className="honeypot-index-info">
+                          <div className="top-info">
+                            <div className="region-info">{honeypot.region}</div>
+                            <div className="category-info">{honeypot.interestName}</div>
+                            <div className="honeypot-status">{honeypot.closureStatus}</div>
+                          </div>
+                          <p className="honeypot-title">{honeypot.honeypotTitle}</p>
+                          <div className="honeypot-schedule">
+                            <div>일정</div>
+                            <p className="honeypot-date">{honeypot.eventDate}</p>
+                            <p className="total-member">
+                              참여인원 {honeypot.approvedCount + 1} / {honeypot.totalMember}
+                            </p>
+                          </div>
+                          <p className="end-date">{honeypot.endDate} 까지 모집해요</p>
+                        </div>
+                      </div>
+                    ))}
                   </div>
+                  }
                 </li>
               </ul>
             </div>

--- a/src/pages/cultureInfo/CultureInfo.js
+++ b/src/pages/cultureInfo/CultureInfo.js
@@ -3,6 +3,7 @@ import CardType from "../../components/cultureInfo/CardType";
 import EarlySlide from "../../components/cultureInfo/EarlySlide";
 import HotSlide from "../../components/cultureInfo/HotSlide";
 import styles from "./CultureInfo.module.css";
+import "../honeypot/HoneypotPage.css";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import LoadingSpinner from "../../components/commons/Loading";
@@ -13,51 +14,59 @@ export default function CultureInfo(props) {
 
   //State 설정
   const [cultureList, setCultureList] = useState(null); // 공연/전시 전체 목록 
+  const [filteredList, setFilteredList] = useState(null) // 필터&검색 리스트
   const [earlyBirdInfo, setEarlyBirdInfo] = useState([]); // 얼리버드 리스트
+  const [hotList, setHotList] = useState([]) // HOT 공연/전시 정보
   const { detailDataList } = props;  // detailDataList를 props에서 가져옴
   const [category, setCategory] = useState('all') // 선택한 카테고리 - 초기값은 전체
   const [totalCount, setTotalCount] = useState(0); // 공연/전시 총 갯수
+  const [publicCount, setPublicCount] = useState(0); // 공연/전시 공공 api 총 갯수
   const [exhibitCount, setExhibitCount] = useState(0); // 전시회 갯수
   const [concertCount, setConcertCount] = useState(0); // 공연 갯수
   const [musicalCount, setMusicalCount] = useState(0); // 뮤지컬 갯수
   const [festivalCount, setFestivalCount] = useState(0); // 행사/축제 갯수
   const [popCount, setPopCount] = useState(0); // 팝업스토어 갯수
   const [earlyCount, setEarlyCount] = useState(0); // 얼리버드 갯수
-  //const [searchValue, setSearchValue] = useState(null) // 검색어
-  const [genreCategory, setGenreCategory] = useState("all") // 장르 카테고리  - 전체로 초기화
+  const [isEarly, setIsEarly] = useState(false) // 얼리버드 선택 여부
+  const [searchValue, setSearchValue] = useState(null) // 검색어
   const [subFilter, setSubFilter] = useState("마감임박순") // 최신 등록순 필터로 초기화
   const [areaFilter, setAreaFilter] = useState("전체 지역") // 지역 필터 - 전체 지역으로 초기화
 
   // 페이지네이션 상태 추가
   const [currentPage, setCurrentPage] = useState(1);
   const cardItemsPerPage = 4;
-  const tableItemsPerPage = 2;
+  const tableItemsPerPage = 4;
 
   // 장르 카테고리 선택 후, 등록순 / 지역 카테고리 선택
   // 장르 카테고리를 재설정할 경우, 하위 - 등록순 / 지역 카테고리 초기화
 
-  const navigate = useNavigate();  
-
+  // 총 갯수를 계산하는 함수
+  const calculateTotalCount = (publicCnt, earlyCnt) => {
+    return Number(publicCnt) + earlyCnt;
+  };
+  
   useEffect(
     () => {
-      //얼리버드 공연/전시 리스트 전체 조회 api 호출
-      // EventsInfoApi({setEvents});
-      EarlyBirdInfoApi({setEarlyBirdInfo}, "all");
+        //얼리버드 공연/전시 리스트 전체 조회 api 호출
+        EarlyBirdInfoApi({setEarlyBirdInfo}, "all");
+        const earlyCount = earlyBirdInfo?.length || 0;
+        setEarlyCount(earlyCount);
+        setTotalCount(calculateTotalCount(publicCount, earlyCount));      
     },[]
   );  
-
+  
   //app.js에서 전달받은 api정보 state 저장
   useEffect(
     () => {
-      if (props.cultureList) { // api정보 정상적으로 불러오면   
+      if (props.cultureList && earlyBirdInfo) { // api정보 정상적으로 불러오면   
         const cultureListObj = JSON.parse(props.cultureList); // cultureList를 JavaScript 객체로 변환
-        // const cultureListObj = (JSON.parse(props.cultureList)).perforList.filter(item => item.realmName === genre || item.title.match("전시")); // cultureList를 JavaScript 객체로 변환
         cultureListObj.perforList.sort((a,b) => {return Number(a.endDate) - Number(b.endDate)}) // 마감임박순으로 초기화
         
         const totalCount = cultureListObj.totalCount; // totalCount 값 가져오기
-        console.log("totalCount: ", totalCount);
-        setTotalCount(totalCount);
-
+        console.log("totalCount from public api: ", totalCount);
+        setPublicCount(totalCount);          
+        setTotalCount(calculateTotalCount(totalCount, earlyCount));
+        
         // realmName 값에 따른 갯수 확인
         const realmCounts = {"전시" : 0 , "공연" : 0 , "뮤지컬" : 0, "축제" : 0, "팝업" : 0, "얼리버드" : 0};
         cultureListObj.perforList.forEach(item => {
@@ -74,32 +83,33 @@ export default function CultureInfo(props) {
             realmCounts["축제"]++;
           } else if(realmName == "팝업"){
             realmCounts["팝업"]++;
-          } else if(realmName == "얼리버드"){
-            realmCounts["얼리버드"]++;
           }
         });
+
         setExhibitCount(realmCounts["전시"]);
         setConcertCount(realmCounts["공연"]);
         setMusicalCount(realmCounts["뮤지컬"]);
         setFestivalCount(realmCounts["축제"]);
-        setEarlyCount(realmCounts["얼리버드"]);
-
+        
         console.log("realmName 별 갯수: ", realmCounts);
-
-        setCultureList(JSON.parse(props.cultureList)); // JSON형태로 cultureList 저장       
-
+        
+        setCultureList(JSON.parse(props.cultureList)); // JSON형태로 cultureList 저장 
+        setFilteredList({...cultureListObj , perforList : cultureListObj.perforList.sort((a,b) => {return Number(a.endDate) - Number(b.endDate)})})
+        setHotList(JSON.parse(props.cultureList));          
+        
         //공연/전시 대분류 카테고리 버튼
         const genreFilterList = document.querySelectorAll(`.${styles.filter_genre_list} li`);
-
+        
         genreFilterList.forEach(genreBtn => { // 공연/전시 대분류 카테고리 버튼 각각에
           genreBtn.addEventListener('click', (e) => { //클릭 이벤트 추가
             const genre = e.currentTarget.dataset.genre; // 클릭한 li 태그에 지정한 data-genre 사용자 지정 데이터 특성 가져오기
-            setGenreCategory(genre);
+            setCategory(genre);
 
             //카테고리 버튼 클릭시 마다, 하단 필터 초기화
             setSubFilter("마감임박순");
             setAreaFilter("전체 지역");
-
+            setSearchValue(null);            
+            
             // 모든 버튼에서 active 클래스 제거
             genreFilterList.forEach(item => {
               item.classList.remove(`${styles.active}`);
@@ -107,182 +117,178 @@ export default function CultureInfo(props) {
 
             // 현재 클릭된 버튼에 active 클래스 추가
             e.currentTarget.classList.add(`${styles.active}`);
-
+            
             // 해당 카테고리에 맞는 cultureList 필터링
             let filteredList = [];
             if (genre === "all") { // 전체
-              filteredList = cultureListObj.perforList; // 전체보기일 경우 전체 리스트 반환
+              filteredList = cultureListObj.perforList.sort((a, b) => Number(a.endDate) - Number(b.endDate)); // 전체보기일 경우 전체 리스트 반환
+              setIsEarly(false);
             } else if(genre === "미술"){ // 전시
-              filteredList = cultureListObj.perforList.filter(item => item.realmName === genre || item.title.match("전시"));
+              filteredList = cultureListObj.perforList.filter(item => item.realmName === genre || item.title.match("전시")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
+              setIsEarly(false);
             } else if(genre === "음악"){ // 공연
-              filteredList = cultureListObj.perforList.filter(item => item.realmName === genre || item.realmName === "연극" || item.title.match("음악") || item.title.match("영화"));
+              filteredList = cultureListObj.perforList.filter(item => item.realmName === genre || item.realmName === "연극" || item.title.match("음악") || item.title.match("영화")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
+              setIsEarly(false);
             } else if(genre === "뮤지컬"){ // 뮤지컬
-              filteredList = cultureListObj.perforList.filter(item => item.title.match("뮤지") || item.title.match("뮤지컬"));
+              filteredList = cultureListObj.perforList.filter(item => item.title.match("뮤지") || item.title.match("뮤지컬")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
+              setIsEarly(false);
             } else if(genre === "축제"){ // 행사 / 축제
-              filteredList = cultureListObj.perforList.filter(item => item.title.match("축제") || item.title.match("페스티벌"));
+              filteredList = cultureListObj.perforList.filter(item => item.title.match("축제") || item.title.match("페스티벌")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
+              setIsEarly(false);
+            } else if(genre === "얼리버드"){ // 얼리버드
+              filteredList = earlyBirdInfo.sort((a,b) => {return Number(a.saleEndDate) - Number(b.saleEndDate)});
+              setIsEarly(true);
             }
 
             // 필터링된 결과를 cultureList 상태에 업데이트
             setCultureList({ ...cultureListObj, perforList: filteredList });
+            setFilteredList({ ...cultureListObj, perforList: filteredList });
             setCurrentPage(1); // 페이지를 1로 초기화
           });
         }); 
-
-        // 공연/전시 세부 필터
-      const detailFilter = document.querySelectorAll(`.${styles.detail_filter_list} > li`);
-
-      // 공연/전시 세부 필터링 리스트 아이템
-      const detailFilterItem = document.querySelectorAll(`.${styles.detail_filter_list} > li > ul > li`);
-
-      // detailFilter.forEach(detailBtn => { //디테일 필터 각각에
-      //   detailBtn.addEventListener('click', (e) => { // 클릭 이벤트 추가
-      //     e.currentTarget.classList.contains(`${styles.active}`) ? e.currentTarget.classList.remove(`${styles.active}`) : e.currentTarget.classList.add(`${styles.active}`); // 클릭한 버튼의 활성화 여부에 따라 active 클래스 추가 또는 삭제
-      //     e.currentTarget.childNodes[1].classList.contains(`${styles.active}`) ? e.currentTarget.childNodes[1].classList.remove(`${styles.active}`) : e.currentTarget.childNodes[1].classList.add(`${styles.active}`); // 클릭한 버튼 > 필터링 리스트의 active 클래스 추가 또는 삭제
-      //   })
-      // });
-
-      detailFilter.forEach(detailBtn => {
-        detailBtn.addEventListener('click', (e) => {
-          e.currentTarget.classList.toggle(`${styles.active}`);
-          e.currentTarget.childNodes[1].classList.toggle(`${styles.active}`);
-          //     e.currentTarget.classList.contains(`${styles.active}`) ? e.currentTarget.classList.remove(`${styles.active}`) : e.currentTarget.classList.add(`${styles.active}`); // 클릭한 버튼의 활성화 여부에 따라 active 클래스 추가 또는 삭제
-          // e.currentTarget.childNodes[1].classList.contains(`${styles.active}`) ? e.currentTarget.childNodes[1].classList.remove(`${styles.active}`) : e.currentTarget.childNodes[1].classList.add(`${styles.active}`); // 클릭한 버튼 > 필터링 리스트의 active 클래스 추가 또는 삭제
-        });
-      });
-
-      // detailFilterItem.forEach(detailItem => { // 디테일 필터링 리스트 아이템 각각에
-      //   detailItem.addEventListener('click', (e) => { // 클릭 이벤트 추가
-      //     e.currentTarget.closest("ul").classList.remove(`.${styles.active}`); // 디테일 필터링 리스트 비활성화
-      //     console.log("현재 클릭한 필터 : " + e.currentTarget.innerText);
-      //     // 해당 카테고리에 맞는 cultureList 필터링
-      //     let filteredList = [];
-          
-      //     if (e.currentTarget.innerText === "마감임박순") { // 마감임박순
-      //       filteredList = cultureListObj.perforList.sort((a,b) => {return Number(a.endDate) - Number(b.endDate)});
-      //       setSubFilter(e.currentTarget.innerText);            
-      //     } else if(e.currentTarget.innerText === "최신등록순"){ // 최신등록순
-      //       filteredList = cultureListObj.perforList.sort((a,b) => {return Number(b.startDate) - Number(a.startDate)});
-      //       setSubFilter(e.currentTarget.innerText);
-      //       console.log("최신등록순 : " + JSON.stringify(cultureListObj));
-      //     } else if(e.currentTarget.innerText === "가격순"){ // 가격순
-      //       filteredList = cultureListObj.perforList.sort((a,b) => {return Number(b.startDate) - Number(a.startDate)});
-      //       setSubFilter(e.currentTarget.innerText);
-      //     } else if(e.currentTarget.innerText === "허니팟 많은순"){ // 허니팟 많은 순
-      //       setSubFilter(e.currentTarget.innerText);
-      //     } else if(e.currentTarget.innerText === "인기순"){ // 인기순(예매 많은 순)
-      //       setSubFilter(e.currentTarget.innerText);
-      //     } else if(e.currentTarget.innerText == "전체 지역"){ // 클릭한 필터가 전체 지역인 경우
-      //         filteredList = cultureListObj.perforList;
-      //         setAreaFilter("전체 지역");
-      //     }else{                
-      //       filteredList = cultureList.perforList.filter(item => item.area.match(e.currentTarget.innerText));
-      //       setAreaFilter(e.currentTarget.innerText);
-      //     }
-
-      //     // 필터링된 결과를 cultureList 상태에 업데이트
-      //     setCultureList({ ...cultureListObj, perforList: filteredList });
-      //     setCurrentPage(1); // 페이지를 1로 초기화
-      //   })
-      // });
-      const handleDetailItemClick = (e) => {
-        e.currentTarget.closest("ul").classList.remove(`.${styles.active}`);
-        console.log("현재 클릭한 필터 : " + e.currentTarget.innerText);
-        console.log()
-
-        let filteredList = [];
-
-        if (e.currentTarget.innerText === "마감임박순") {
-          filteredList = cultureList.perforList.sort((a, b) => Number(a.endDate) - Number(b.endDate));
-          setSubFilter(e.currentTarget.innerText);
-        } else if (e.currentTarget.innerText === "최신등록순") {
-          filteredList = cultureList.perforList.sort((a, b) => Number(b.startDate) - Number(a.startDate));
-          setSubFilter(e.currentTarget.innerText);
-        } else if (e.currentTarget.innerText === "가격순") {
-          filteredList = cultureListObj.perforList.sort((a, b) => Number(b.startDate) - Number(a.startDate));
-          setSubFilter(e.currentTarget.innerText);
-        } else if (e.currentTarget.innerText === "허니팟 많은순") {
-          setSubFilter(e.currentTarget.innerText);
-        } else if (e.currentTarget.innerText === "인기순") {
-          setSubFilter(e.currentTarget.innerText);
-        } else if (e.currentTarget.innerText === "전체 지역") {
-          filteredList = cultureListObj.perforList;
-          setAreaFilter("전체 지역");
-        } else {
-          filteredList = cultureListObj.perforList.filter(item => item.area.match(e.currentTarget.innerText));
-          setAreaFilter(e.currentTarget.innerText);
-        }
-
-        setCultureList({ ...cultureList, perforList: filteredList });
-        // setCultureList({ ...cultureListObj, perforList: filteredList });
-        setCurrentPage(1);
-      };
-
-      detailFilterItem.forEach(detailItem => {
-        detailItem.addEventListener('click', handleDetailItemClick);
-      });
-
 
         return () => {
           // 클릭 이벤트 리스너 해제 (cleanup)
           genreFilterList.forEach(genreBtn => {
             genreBtn.removeEventListener('click', () => {});
           });
-
-          detailFilter.forEach(detailBtn => { //디테일 필터 각각에
-            detailBtn.removeEventListener('click', () => {})
-          });
-          
-          detailFilterItem.forEach(detailItem => { // 디테일 필터링 리스트 아이템 각각에
-            detailItem.removeEventListener('click', () => {})
-          });
         };        
       }
-    }, [props.cultureList]
+    }, [props.cultureList, earlyBirdInfo]
   );
 
+  useEffect(
+    ()=>{
+      
+      setTotalCount(Number(publicCount) + earlyCount);
+    },[earlyCount, publicCount]
+  );
+  
   useEffect(() => {
     console.log("cultureList : ", cultureList);
   }, [cultureList]);
-
-
+  
+  
   useEffect(
     () => {
-
       window.scrollTo(0, 0); //페이지 이동시, 최상단으로 스크롤 위치
-
-      // 공연/전시 카드/테이블 타입 보기 필터
-      const viewFilter = document.querySelectorAll(`.${styles.view_filter_list} > li`);
-      const viewCardType = document.querySelector(`.${styles.culture_list_box}`); // 카드 타입 영역
-      const viewTableType = document.querySelector(`.${styles.culture_table}`); // 테이블 타입 영역
-
-      viewFilter.forEach(viewBtn => { // 보기 필터 각각에 
-        viewBtn.addEventListener('click', (e) => { // 클릭 이벤트 추가
-          if (e.currentTarget.classList.contains(`${styles.active}`)) { //클릭한 버튼이 이미 활성화된 상태라면
-            return false;
-          } else { // 클릭한 버튼이 비활성화된 상태라면
-            e.currentTarget.classList.add(`${styles.active}`); // 활성화 상태로 전환
-            console.log('현재 클릭한 버튼 :' + e.currentTarget.classList);
-            if (e.currentTarget.classList.contains(`${styles.left_filter}`)) { // 카드 형식 버튼이 활성화라면              
-              e.currentTarget.nextElementSibling.classList.remove(`${styles.active}`);
-              e.currentTarget.childNodes[0].setAttribute('src', `/images/cultureInfo/icon_home_white.png`);// 버튼 아이콘 활성화 이미지 변경
-              e.currentTarget.nextElementSibling.childNodes[0].setAttribute('src', `/images/commons/icon_list_colored.png`);// 버튼 아이콘 비활성화 이미지 변경
-              viewCardType.classList.add(`${styles.active}`);
-              viewTableType.classList.remove(`${styles.active}`);
-            } else { // 테이블 형식 버튼이 활성화라면
-              e.currentTarget.previousElementSibling.classList.remove(`${styles.active}`);
-              e.currentTarget.childNodes[0].setAttribute('src', `/images/commons/icon_list_white.png`);// 버튼 아이콘 활성화 이미지 변경
-              e.currentTarget.previousElementSibling.childNodes[0].setAttribute('src', `/images/cultureInfo/icon_home_colored.png`);// 버튼 아이콘 비활성화 이미지 변경
-              viewTableType.classList.add(`${styles.active}`);
-              viewCardType.classList.remove(`${styles.active}`);
-            }
-          }
-        })
-      })
-
-      return () => {
-      }
     }, []
   );
+
+
+  // 서브 필터
+  const subFilterHandler = (e) => {
+    e.currentTarget.classList.toggle(`${styles.active}`);
+    e.currentTarget.childNodes[1].classList.toggle(`${styles.active}`);
+  }
+
+  //서브 필터 아이템 
+  const subFilterItemHandler = (e) => {
+      e.currentTarget.closest("ul").classList.remove(`.${styles.active}`);
+      const cultureListObj = JSON.parse(props.cultureList);
+      console.log("현재 클릭한 필터 : " + e.currentTarget.innerText);
+      console.log("현재 선택한 카테고리 : " + category);
+
+      let filteredListCategory = [];
+      let filteredListAfterSubFiltered = [];
+
+      if (category === "all") { // 전체
+        filteredListCategory = cultureListObj.perforList.sort((a, b) => Number(a.endDate) - Number(b.endDate)); // 전체보기일 경우 전체 리스트 반환
+      } else if(category === "미술"){ // 전시
+        filteredListCategory = cultureListObj.perforList.filter(item => item.realmName === category || item.title.match("전시")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
+      } else if(category === "음악"){ // 공연
+        filteredListCategory = cultureListObj.perforList.filter(item => item.realmName === category || item.realmName === "연극" || item.title.match("음악") || item.title.match("영화")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
+      } else if(category === "뮤지컬"){ // 뮤지컬
+        filteredListCategory = cultureListObj.perforList.filter(item => item.title.match("뮤지") || item.title.match("뮤지컬")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
+      } else if(category === "축제"){ // 행사 / 축제
+        filteredListCategory = cultureListObj.perforList.filter(item => item.title.match("축제") || item.title.match("페스티벌")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
+      } else if(category === "얼리버드"){ // 얼리버드
+        filteredListCategory = cultureListObj.sort((a,b) => {return Number(a.saleEndDate) - Number(b.saleEndDate)});
+      }
+
+      if (e.currentTarget.innerText === "마감임박순") {
+        filteredListAfterSubFiltered = areaFilter === "전체 지역" ? filteredListCategory.sort((a, b) => Number(a.endDate) - Number(b.endDate)) : filteredListCategory.filter(item => item.area.match(areaFilter)).sort((a, b) => Number(a.endDate) - Number(b.endDate));
+        setSubFilter(e.currentTarget.innerText);
+      } else if (e.currentTarget.innerText === "최신등록순") {
+        filteredListAfterSubFiltered = areaFilter === "전체 지역" ? filteredListCategory.sort((a, b) => Number(b.startDate) - Number(a.startDate)) : filteredListCategory.filter(item => item.area.match(areaFilter)).sort((a, b) => Number(b.startDate) - Number(a.startDate));
+        setSubFilter(e.currentTarget.innerText);
+      } else if (e.currentTarget.innerText === "가격순") {
+        filteredListAfterSubFiltered = filteredListCategory.sort((a, b) => Number(b.startDate) - Number(a.startDate));
+        setSubFilter(e.currentTarget.innerText);
+      } else if (e.currentTarget.innerText === "허니팟 많은순") {
+        setSubFilter(e.currentTarget.innerText);
+      } else if (e.currentTarget.innerText === "인기순") {
+        setSubFilter(e.currentTarget.innerText);
+      }else if (e.currentTarget.innerText === "전체 지역") {
+        setAreaFilter("전체 지역");
+        filteredListAfterSubFiltered = filteredListCategory;
+      } else {
+        console.log("areaFilter : " + areaFilter);
+        setAreaFilter(e.currentTarget.innerText);
+        console.log("after areaFilter : " + areaFilter);
+        const areaFiltered = filteredListCategory.filter(item => item.area.match(e.currentTarget.innerText));
+        filteredListAfterSubFiltered = subFilter === "마감임박순" ? areaFiltered.sort((a, b) => Number(a.endDate) - Number(b.endDate)) : areaFiltered.sort((a, b) => Number(b.startDate) - Number(a.startDate));
+      }
+
+      setFilteredList({ ...cultureListObj, perforList: filteredListAfterSubFiltered });
+      setCurrentPage(1);
+    };
+
+  // select view
+  // 공연/전시 카드/테이블 타입 보기 필터
+  const selectViewHandler =  (e) => { // 클릭 이벤트 추가
+    const viewCardType = document.querySelector(`.${styles.culture_list_box}`); // 카드 타입 영역
+    const viewTableType = document.querySelector(`.${styles.culture_table}`);
+    if (e.currentTarget.classList.contains(`${styles.active}`)) { //클릭한 버튼이 이미 활성화된 상태라면
+      return false;
+    } else { // 클릭한 버튼이 비활성화된 상태라면
+      e.currentTarget.classList.add(`${styles.active}`); // 활성화 상태로 전환
+      console.log('현재 클릭한 버튼 :' + e.currentTarget.classList);
+      if (e.currentTarget.classList.contains(`${styles.left_filter}`)) { // 카드 형식 버튼이 활성화라면              
+        e.currentTarget.nextElementSibling.classList.remove(`${styles.active}`);
+        e.currentTarget.childNodes[0].setAttribute('src', `/images/cultureInfo/icon_home_white.png`);// 버튼 아이콘 활성화 이미지 변경
+        e.currentTarget.nextElementSibling.childNodes[0].setAttribute('src', `/images/commons/icon_list_colored.png`);// 버튼 아이콘 비활성화 이미지 변경
+        viewCardType.classList.add(`${styles.active}`);
+        viewTableType.classList.remove(`${styles.active}`);
+      } else { // 테이블 형식 버튼이 활성화라면
+        e.currentTarget.previousElementSibling.classList.remove(`${styles.active}`);
+        e.currentTarget.childNodes[0].setAttribute('src', `/images/commons/icon_list_white.png`);// 버튼 아이콘 활성화 이미지 변경
+        e.currentTarget.previousElementSibling.childNodes[0].setAttribute('src', `/images/cultureInfo/icon_home_colored.png`);// 버튼 아이콘 비활성화 이미지 변경
+        viewTableType.classList.add(`${styles.active}`);
+        viewCardType.classList.remove(`${styles.active}`);
+      }
+    }
+  }
+
+  // 검색어 입력 처리
+  const searchTitleWord = (e) => {
+    const { value } = e.target;
+    setSearchValue(value);
+    // 검색어가 없는 경우 전체 목록 보여주기
+    if (value === '') {
+        const filteredData = cultureList.perforList;
+        setFilteredList({ ...cultureList, perforList: filteredData });
+    }
+  };
+  // 엔터키 처리
+  const handleKeyPress = (e) => {
+      if (e.key === 'Enter') {
+          onClickSearchInput();
+      }
+  };
+  // 검색 버튼 클릭 처리
+  const onClickSearchInput = () => {
+      // 검색어가 비어있는 경우 전체 목록 보여주기
+      const filteredData = searchValue === '' || searchValue === null
+          ? filteredList
+          : cultureList.perforList.filter(cultureItem =>
+            cultureItem.title.toLowerCase().includes(searchValue.toLowerCase()) &&
+              (areaFilter === '전체 지역' || cultureItem.region === areaFilter)
+          );
+          console.log("searching filteredData", filteredData[0]);
+      setCultureList({ ...cultureList, perforList: filteredData });
+      setCurrentPage(1);
+  };
 
   // 현재 페이지에 따른 데이터를 슬라이싱하는 함수
   const getCurrentPageData = (items, itemsPerPage, page) => {
@@ -368,8 +374,8 @@ export default function CultureInfo(props) {
     );
   };
 
-  const cardData = getCurrentPageData(cultureList?.perforList, cardItemsPerPage, currentPage); //카드형 페이지 데이터
-  const tableData = getCurrentPageData(cultureList?.perforList, tableItemsPerPage, currentPage); //테이블형 페이지 데이터
+  const cardData = getCurrentPageData(filteredList?.perforList, cardItemsPerPage, currentPage); //카드형 페이지 데이터
+  const tableData = getCurrentPageData(filteredList?.perforList, tableItemsPerPage, currentPage); //테이블형 페이지 데이터
 
 
   return (
@@ -395,7 +401,7 @@ export default function CultureInfo(props) {
                 <li></li>
               </ul>
               {/* {HotSlide()} */}
-              {cultureList && <HotSlide cultureList={cultureList} />}
+              {hotList && <HotSlide cultureList={hotList} />}
               {/* {cultureList ? <HotSlide cultureList={cultureList} /> : <LoadingSpinner />} */}
             </div>
           </div>
@@ -419,7 +425,7 @@ export default function CultureInfo(props) {
             <p className={styles.sec_tit}>공연/전시 둘러보기</p>
             <ul className={`${styles.filter_genre_list} ${styles.flex_center}`}>
               <li className={`${styles.flex_center} ${styles.active}`} data-genre="all">
-                <p>전시/행사 전체보기</p>
+                <p>전체보기</p>
                 <span className={styles.filter_count}>{totalCount}</span>
               </li>
               <li className={styles.flex_center} data-genre="미술">
@@ -453,46 +459,52 @@ export default function CultureInfo(props) {
             {/* 해당 공연/전시 세부 필터링 버튼 리스트 */}
             <div className={`${styles.filter_box} ${styles.flex_between}`}>
               <ul className={`${styles.detail_filter_list} ${styles.flex_start}`}>
-                <li className={styles.left_filter}>
+                <li className={styles.left_filter} onClick={(e) => subFilterHandler(e)}>
                   <span className={`${styles.selected_filter} ${styles.left} ${styles.flex_between}`}><span className={`${styles.selected_option} ${styles.left_detail_selected}`}>{subFilter}</span><img src={`${process.env.PUBLIC_URL}/images/commons/icon_arrow_bottom_main_color.png`} alt="arrow direction bottom icon" className={styles.filter_arrow_icon} /></span>
                   <ul>
-                    <li data-filter="deadline">마감임박순</li>
-                    <li data-filter="lately">최신등록순</li>
-                    <li data-filter="low">가격낮은순</li>
-                    <li data-filter="honeyPot">허니팟 많은순</li>
-                    <li data-filter="hot">인기순</li>
+                    <li data-filter="deadline" onClick={(e) => subFilterItemHandler(e)}>마감임박순</li>
+                    <li data-filter="lately" onClick={(e) => subFilterItemHandler(e)}>최신등록순</li>
+                    {/* <li data-filter="low">가격낮은순</li> */}
+                    <li data-filter="honeyPot" onClick={(e) => subFilterItemHandler(e)}>허니팟 많은순</li>
+                    {/* <li data-filter="hot">인기순</li> */}
                   </ul>
                 </li>
-                <li className={`${styles.right_filter} ${styles.region_filter}`}>
+                <li className={`${styles.right_filter} ${styles.region_filter}`} onClick={(e) => subFilterHandler(e)}>
                   <span className={`${styles.selected_filter} ${styles.right} ${styles.flex_between}`}><span className={`${styles.selected_option} ${styles.right_detail_selected}`}>{areaFilter}</span><img src={`${process.env.PUBLIC_URL}/images/commons/icon_arrow_bottom_main_color.png`} alt="arrow direction bottom icon" className={styles.filter_arrow_icon} /></span>
                   <ul>
-                    <li>전체 지역</li>
-                    <li>서울</li>
-                    <li>인천</li>
-                    <li>부산</li>
-                    <li>경기</li>
-                    <li>충북</li>
-                    <li>충남</li>
-                    <li>경남</li>
-                    <li>경북</li>
-                    <li>대구</li>
-                    <li>대전</li>
-                    <li>광주</li>
-                    <li>세종</li>
-                    <li>울산</li>
-                    <li>강원</li>
-                    <li>전남</li>
-                    <li>전북</li>
-                    <li>제주</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>전체 지역</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>서울</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>인천</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>부산</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>경기</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>충북</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>충남</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>경남</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>경북</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>대구</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>대전</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>광주</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>세종</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>울산</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>강원</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>전남</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>전북</li>
+                    <li onClick={(e) => subFilterItemHandler(e)}>제주</li>
                   </ul>
                 </li>
               </ul>
 
+              {/* 검색창 */}
+              <div className='search-wrapper'>
+                <input className='text-search' onChange={searchTitleWord} onKeyPress={handleKeyPress} type='text' placeholder="검색어를 입력하세요."/>
+                <button onClick={onClickSearchInput} className='submit-btn' type='button'></button>
+              </div>
+
               <ul className={`${styles.view_filter_list} ${styles.flex_start}`}>
-                <li className={`${styles.left_filter} ${styles.active} ${styles.flex_center}`}>
+                <li className={`${styles.left_filter} ${styles.active} ${styles.flex_center}`} onClick={(e) =>  selectViewHandler(e)}>
                   <img src={`${process.env.PUBLIC_URL}/images/cultureInfo/icon_home_white.png`} alt="view card pattern icon" />
                 </li>
-                <li className={`${styles.right_filter} ${styles.flex_center}`}>
+                <li className={`${styles.right_filter} ${styles.flex_center}`} onClick={(e) =>  selectViewHandler(e)}>
                   <img src={`${process.env.PUBLIC_URL}/images/commons/icon_list_colored.png`} alt="view table pattern icon" />
                 </li>
               </ul>
@@ -501,36 +513,42 @@ export default function CultureInfo(props) {
             <p className={styles.culture_notice_txt}>* 표시 가격은 성인 1인 기준 가격입니다.</p>
 
             {/* 공연/전시 리스트 */}
-            {/* 카드 형식 */}
-            <div className={`${styles.culture_list_box} ${styles.active}`}>
-              <ul className={`${styles.culture_list} ${styles.flex_start}`}>
-                {/* {CardType()} */}
-                {/* {cultureList && detailDataList && (<CardType cultureList={cultureList} detailDataList={detailDataList} />)} */}
-                {cultureList && detailDataList && cardData && (<CardType cultureList={cardData} detailDataList={detailDataList} />)}
-              </ul>
-              {/* <span className={styles.view_more_btn}>더보기</span> */}
-              <Pagination
-                items={cultureList?.perforList}
-                itemsPerPage={cardItemsPerPage}
-                currentPage={currentPage}
-                onPageChange={handlePageChange}
-              />
+            {!filteredList?.perforList ?
+            <div className={styles.cultureList_null}>
+              <p>현재 해당 정보가 존재하지 않습니다.</p>
+              <p>빠른 정보 업데이트로 찾아뵙겠습니다.</p>
             </div>
-            {/* //카드 형식 */}
+            :
+              /* 카드 형식 */
+              <>
+                <div className={`${styles.culture_list_box} ${styles.active}`}>
+                  <ul className={`${styles.culture_list} ${styles.flex_start}`}>
+                    {/* {CardType()} */}
+                    {/* {cultureList && detailDataList && (<CardType cultureList={cultureList} detailDataList={detailDataList} />)} */}
+                    {filteredList && detailDataList && cardData && (<CardType cultureList={cardData} detailDataList={detailDataList} earlyCheck={isEarly}/>)}
+                  </ul>
+                  {/* <span className={styles.view_more_btn}>더보기</span> */}
+                  <Pagination
+                    items={filteredList?.perforList}
+                    itemsPerPage={cardItemsPerPage}
+                    currentPage={currentPage}
+                    onPageChange={handlePageChange}
+                  />
+                </div>
+                {/* //카드 형식 */}
 
-            {/* 테이블 형식 */}
-            <div className={styles.culture_table}>
-              {/* {TableType()} */}
-              {/* {cultureList && detailDataList && <TableType cultureList={cardData} detailDataList={detailDataList} />} */}
-              {cultureList && detailDataList && tableData && <TableType cultureList={tableData} detailDataList={detailDataList} />}
-              <Pagination
-                items={cultureList?.perforList}
-                itemsPerPage={tableItemsPerPage}
-                currentPage={currentPage}
-                onPageChange={handlePageChange}
-              />
-            </div>
-            {/*//테이블 형식 */}
+                { /* 테이블 형식 */}
+                <div className={styles.culture_table}>
+                  {filteredList && detailDataList && tableData && <TableType cultureList={tableData} detailDataList={detailDataList} earlyCheck={isEarly}/>}
+                  <Pagination
+                    items={filteredList?.perforList}
+                    itemsPerPage={tableItemsPerPage}
+                    currentPage={currentPage}
+                    onPageChange={handlePageChange}
+                  />
+                </div>
+              </>}
+              {/*//테이블 형식 */}
           </div>
         </div>
         {/* //공연/전시 둘러보기 */}

--- a/src/pages/cultureInfo/CultureInfo.module.css
+++ b/src/pages/cultureInfo/CultureInfo.module.css
@@ -106,6 +106,7 @@ li.right_filter .selected_filter {width: 128px;}
 
 /* 전시/공연 리스트 */
 /* 카드 형식 */
+.cultureList_null {display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 300px; height: calc(100vh - 300px); font-size: 20px; }
 .culture_list_box.active {display: flex;}
 .culture_list_box{display: none; flex-direction: column; align-items: center; padding-bottom: 100px;}
 .culture_list {align-items: flex-start; flex-wrap: wrap; width: 100%;}
@@ -114,7 +115,7 @@ li.right_filter .selected_filter {width: 128px;}
 .culture_list li a {display: block;}
 .culture_list li a:hover .culture_img{border: 1px solid var(--point-color);} 
 .culture_img {position: relative; width: 100%; height: 348px; border-radius:20px; border: 1px solid rgba(255, 183, 85,.2); overflow: hidden; transition: border 200ms ease-in-out;}
-.culture_img img {width: 100%; height: 100%; object-fit: cover; }
+.culture_img img {width: 100%; height: 100%; object-fit: cover; object-position: top;}
 .culture_mark {position: absolute; top: 10px; right:10px; display: inline-block; height: 30px; padding:0 10px; line-height: 30px; color: #ffffff; background-color: var(--point-color); border-radius:30px; font-size: 14px; font-weight: var(--medium);}
 .culture_item_txt {padding-top: 20px;}
 .culture_tit {font-size: 20px; font-weight: var(--bold);}
@@ -171,6 +172,7 @@ li.right_filter .selected_filter {width: 128px;}
 .short_cut_btn {display: block; height: 48px; padding:0 20px; margin-top: 10px; border-radius: 48px; font-size: 18px; font-weight: var(--semiBold); color: #ffffff; line-height: 48px; text-align: center; background-color: var(--main-color); transition: background-color 200ms ease-in-out;}
 .short_cut_btn:hover {background-color: var(--point-color);}
 .price_list p {padding-bottom: 10px;}
+ .price_list.earlyPrice p {padding-bottom: 0;}
 /* .price_list .price {margin-left: 10px;} */
 
 /* detail info 영역 */
@@ -188,6 +190,7 @@ li.right_filter .selected_filter {width: 128px;}
 .info_tit {padding-bottom: 20px; padding-top: 80px; font-size: 24px; font-weight: var(--semiBold);}
 .info_tit:first-of-type {padding-top: 0;}
 .info_description {font-size: 18px; font-weight: var(--regular);}
+.detailInfoText {padding-bottom: 60px; white-space: pre-line;}
 .detail_info_img {width: 100%;}
 .detail_info_img img{width: 100%; object-fit: contain;}
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[FEATURE][CULTUREINFO][EARLYBIRD]

### 💡 작업동기
- 공연/전시 정보 메인 페이지에 얼리버드 REST Api 호출 및 연결하기

### 🔑 주요 변경사항
* 공연/전시 정보 메인 페이지에 얼리버드 조회 REST Api 호출
* 공연/전시 정보 - 얼리버드 상세 페이지에 상세 내용 조회 REST Api 연결
* 하위 필터 기능 적용(마감임박순/최신등록순 & 지역순)
* 검색 영역 추가(기능 작업 중)

### 🏞 스크린샷
### 얼리버드 상세 페이지 연결
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/73331620/a1b92080-0d41-4d52-90e3-b38a79d3ae92)

### 세부 카테고리 필터 기능 적용
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/73331620/4e6eea38-389a-4198-ac30-e25719fbcbe5)

### 관련 이슈
- close #79 

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
