### PR TITLE
[FEATURE][CULTUREINFO][EARLYBIRD]얼리버드 공연/전시 정보 REST Api 호출 및 연결하기

### DIFF
--- a/src/apis/cultureInfo/HoneypotByCultureInfoApi.js
+++ b/src/apis/cultureInfo/HoneypotByCultureInfoApi.js
@@ -1,0 +1,20 @@
+import axios from "axios";
+
+export default function HoneypotByCultureInfoApi({setHoneypots}, {setFilteredHoneypots}, seq) {
+    
+    async function fetchHoneypots() {
+        try {
+            const response = await axios.get('http://localhost:8081/honeypot/listandapproved');
+            console.log("리스폰스는:", response);
+            setHoneypots(response.data);       
+            const filteredHoneypot = response.data.filter(item => item.seqNo === Number(seq)).sort((a,b) => {return Number(a.endDate) - Number(b.endDate)});
+            setFilteredHoneypots(filteredHoneypot); // 초기 필터링 설정 
+            // console.log("response data from api : ", response.data?.filter(item => item.seqNo === seq).sort((a,b) => {return Number(a.endDate) - Number(b.endDate)}) );
+        } catch (error) {
+            console.error('Error 입니다 : ', error);
+        }
+    }
+
+    fetchHoneypots();
+
+}

--- a/src/pages/cultureInfo/CultureDetail.js
+++ b/src/pages/cultureInfo/CultureDetail.js
@@ -1,12 +1,11 @@
 import { useEffect, useState } from "react";
-import styles from "./CultureInfo.module.css";
 import "../../components/honeypot/HoneypotList.css";
+import styles from "./CultureInfo.module.css";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import EarlyBirdInfoApi from "../../apis/cultureInfo/EarlyBirdApi";
-import HoneypotListApi from "../../apis/honeypot/HoneypotListApi";
+import HoneypotByCultureInfoApi from "../../apis/cultureInfo/HoneypotByCultureInfoApi";
 
 export default function CultureDetail(props) {
-  const {isEarly} = props;
   const [detailData, setDetailData] = useState(null); //상세 정보 저장
   const [earlyBirdInfo, setEarlyBirdInfo] = useState(null); // 얼리버드 상세 정보 저장
   const [honeypots, setHoneypots] = useState([]);
@@ -50,11 +49,16 @@ export default function CultureDetail(props) {
   }, [detailData]);
 
   useEffect(() => {
-    if(seq){
-      HoneypotListApi({setHoneypots}, {setFilteredHoneypots});
+    if(seq && honeypots){
+      HoneypotByCultureInfoApi({setHoneypots}, {setFilteredHoneypots}, seq); 
       console.log("honeypots",honeypots);
     }
   }, [seq]);
+
+  useEffect(() => {
+      console.log("filteredHoneypots",filteredHoneypots);
+  }, [filteredHoneypots]);
+
 
   useEffect(
     () => {
@@ -96,7 +100,7 @@ export default function CultureDetail(props) {
     const year = stringDate?.slice(0, 4);
     const month = stringDate?.slice(4, 6);
     const day = stringDate?.slice(6);
-    if (type == "rest") {
+    if (type === "rest") {
       dateFormat = new Date(year + "-" + month + "-" + day); // 날짜 표시 형식
     } else {
       dateFormat = year + "." + month + "." + day; // 날짜 표시 형식
@@ -135,16 +139,16 @@ export default function CultureDetail(props) {
       <div className={styles.contents_cont}>
         <div className={styles.detail_sec_box}>
           <div className={styles.detail_sec}>
-            <p className={`${styles.sec_tit} ${styles.left}`}>{early == false ? detailData?.title.replaceAll('&lt;', `<`).replaceAll('&gt;', `>`).replaceAll("&#39;", "'") : earlyBirdInfo?.ebTitle}</p>
+            <p className={`${styles.sec_tit} ${styles.left}`}>{early === false ? detailData?.title.replaceAll('&lt;', `<`).replaceAll('&gt;', `>`).replaceAll("&#39;", "'") : earlyBirdInfo?.ebTitle}</p>
             <div className={`${styles.detail_summary} ${styles.flex_between}`}>
-              <div className={styles.detail_img}><img src={early == false ? detailData?.imgUrl : earlyBirdInfo?.poster} alt="detail page" /></div>
+              <div className={styles.detail_img}><img src={early === false ? detailData?.imgUrl : earlyBirdInfo?.poster} alt="detail page" /></div>
               <div className={styles.summary_txt_box}>
                 <ul>
-                  <li className={styles.flex_start}><p className={styles.detail_item_tit}>장소</p><p>{early == false ? detailData?.place : earlyBirdInfo?.place}</p></li>
-                  <li className={styles.flex_start}><p className={styles.detail_item_tit}>{early == false ? "기간" : "예매 기간"}</p><p>{early == false ? convertDateFormat(detailData?.startDate, null) : formatDate(earlyBirdInfo?.usageStartDate)} ~ {early == false ? convertDateFormat(detailData?.endDate, null) : formatDate(earlyBirdInfo?.usageEndDate)}</p></li>
-                  {early != false ? <li className={styles.flex_start}><p className={styles.detail_item_tit}>사용 기한</p><p>{early == false ? convertDateFormat(detailData?.startDate, null) : formatDate(earlyBirdInfo?.usageStartDate)} ~ {early == false ? convertDateFormat(detailData?.endDate, null) : formatDate(earlyBirdInfo?.usageEndDate)}</p></li> : null}
-                  {early != false ? <li className={styles.flex_start}><p className={styles.detail_item_tit}>관람 연령</p><p>{earlyBirdInfo?.ageLimit}</p></li> : null}
-                  {early != false ? <li className={styles.flex_start}>
+                  <li className={styles.flex_start}><p className={styles.detail_item_tit}>장소</p><p>{early === false ? detailData?.place : earlyBirdInfo?.place}</p></li>
+                  <li className={styles.flex_start}><p className={styles.detail_item_tit}>{early === false ? "기간" : "예매 기간"}</p><p>{early === false ? convertDateFormat(detailData?.startDate, null) : formatDate(earlyBirdInfo?.usageStartDate)} ~ {early === false ? convertDateFormat(detailData?.endDate, null) : formatDate(earlyBirdInfo?.usageEndDate)}</p></li>
+                  {early !== false ? <li className={styles.flex_start}><p className={styles.detail_item_tit}>사용 기한</p><p>{early === false ? convertDateFormat(detailData?.startDate, null) : formatDate(earlyBirdInfo?.usageStartDate)} ~ {early === false ? convertDateFormat(detailData?.endDate, null) : formatDate(earlyBirdInfo?.usageEndDate)}</p></li> : null}
+                  {early !== false ? <li className={styles.flex_start}><p className={styles.detail_item_tit}>관람 연령</p><p>{earlyBirdInfo?.ageLimit}</p></li> : null}
+                  {early !== false ? <li className={styles.flex_start}>
                     <p className={styles.detail_item_tit}>얼리버드 가격</p>
                     <div className={`${styles.price_list}  ${styles.earlyPrice}`}>
                     <p className={`${styles.price} ${styles.adult}`}>{convertPriceFormat(earlyBirdInfo?.discountPrice)}원</p>
@@ -153,23 +157,23 @@ export default function CultureDetail(props) {
                   <li className={styles.flex_start}>
                     <p className={styles.detail_item_tit}>일반 가격</p>
                     <div className={styles.price_list}>
-                      {early == false ? <p className={`${styles.price} ${styles.adult}`}>{detailData?.price }</p> : <p className={`${styles.price} ${styles.adult}`}>{convertPriceFormat(earlyBirdInfo?.regularPrice)}원</p>}
+                      {early === false ? <p className={`${styles.price} ${styles.adult}`}>{detailData?.price }</p> : <p className={`${styles.price} ${styles.adult}`}>{convertPriceFormat(earlyBirdInfo?.regularPrice)}원</p>}
                       {/* <p>성인<span className={`${styles.price} ${styles.adult}`}>15,000</span>원</p> */}
                       {/* <p>청소년/어린이 <span className={`${styles.price} ${styles.adult}`}>10,000</span>원</p> */}
                     </div>
                   </li>                  
                   <li className={styles.flex_start}>
-                    <p className={styles.detail_item_tit}>{early != false ? "예매처" : "공식 홈페이지"}</p>
+                    <p className={styles.detail_item_tit}>{early !== false ? "예매처" : "공식 홈페이지"}</p>
 
-                    {early == false ? <div className={styles.price_list}>
+                    {early === false ? <div className={styles.price_list}>
                       <p>{detailData?.place}</p>
-                      {detailData?.placeUrl != null || detailData?.placeUrl != "" ? <Link to={detailData?.placeUrl} target="_blank" className={styles.short_cut_btn}>바로가기</Link> : <p>공식 홈페이지 정보가 존재하지 않습니다.\n추후 업데이트 예정입니다.</p>}
+                      {detailData?.placeUrl !== null || detailData?.placeUrl !== "" ? <Link to={detailData?.placeUrl} target="_blank" className={styles.short_cut_btn}>바로가기</Link> : <p>공식 홈페이지 정보가 존재하지 않습니다.\n추후 업데이트 예정입니다.</p>}
 
                     </div> 
                     : 
                     <div className={styles.price_list}>
                       <p>{earlyBirdInfo?.place}</p>
-                      {earlyBirdInfo?.sellerLink != null || earlyBirdInfo?.sellerLink != "" ? <Link to={earlyBirdInfo?.sellerLink} target="_blank" className={styles.short_cut_btn}>바로가기</Link> : <p>예매처 정보가 존재하지 않습니다.\n추후 업데이트 예정입니다.</p>}
+                      {earlyBirdInfo?.sellerLink !== null || earlyBirdInfo?.sellerLink !== "" ? <Link to={earlyBirdInfo?.sellerLink} target="_blank" className={styles.short_cut_btn}>바로가기</Link> : <p>예매처 정보가 존재하지 않습니다.\n추후 업데이트 예정입니다.</p>}
                     </div>
                     }
                   </li>
@@ -191,7 +195,7 @@ export default function CultureDetail(props) {
                 {/* 이용 및 상세 정보 */}
                 <li>                  
                   <p className={styles.info_tit}>상세 정보</p>
-                  {early == false ? <div className={styles.detail_info_img}>
+                  {early === false ? <div className={styles.detail_info_img}>
                     <img src={detailData?.imgUrl} alt={`${detailData?.title} info`} />
                   </div>
                   :
@@ -207,39 +211,66 @@ export default function CultureDetail(props) {
                 {/* 허니팟 정보 */}
                 <li>
                   {/* 등록된 허니팟이 없는 경우 - NULL */}
-                  { !honeypots ? <div className={styles.detail_null_box}>
+                  { filteredHoneypots.length === 0 ? <div className={styles.detail_null_box}>
                     <img src={`${process.env.PUBLIC_URL}/images/commons/logo.png`} alt="null page" />
                     <p className={styles.null_txt}>아직 등록된 허니팟이 없어요</p>
                     <p className={styles.null_txt}>지금 바로 허니팟 호스트가 되어 주세요</p>
-                    <span className={styles.hosting_btn}>허니팟 호스팅</span>
+                    <Link to={"/honeypot/c"} className={styles.hosting_btn}>허니팟 호스팅</Link>
                   </div> 
                   : 
-                  <div className="honeypot-list-container">
-                    {filteredHoneypots.map((honeypot, index) => (
-                    <div key={index} className="one-honeypot-index"
-                      onClick={ () => {navigate(`/honeypot/detail/${honeypot?.honeypotCode}`)}}>
-                        <div className="honeypot-index-poster">
-                          <img src={honeypot.poster} alt="포스터이미지" />
-                          <hr className="honeypot-dashed" />
-                        </div>
-                        <div className="honeypot-index-info">
-                          <div className="top-info">
-                            <div className="region-info">{honeypot.region}</div>
-                            <div className="category-info">{honeypot.interestName}</div>
-                            <div className="honeypot-status">{honeypot.closureStatus}</div>
+                  <div className={styles.honeypotListBox}>
+                    <div className={`honeypot-list-container ${styles.honeypotListCont}`}>
+                      {filteredHoneypots.length > 6 ? [...Array(parseInt(6))].map((honeypot, index) => (
+                      <Link key={index} className="one-honeypot-index"
+                        to={`/honeypot/detail/${filteredHoneypots[index]?.honeypotCode}`}>
+                          {/* onClick={ () => {navigate(`/honeypot/detail/${filteredHoneypots[index]?.honeypotCode}`)}} */}
+                          <div className="honeypot-index-poster">
+                            <img src={filteredHoneypots[index]?.poster} alt="포스터이미지" />
+                            <hr className="honeypot-dashed" />
                           </div>
-                          <p className="honeypot-title">{honeypot.honeypotTitle}</p>
-                          <div className="honeypot-schedule">
-                            <div>일정</div>
-                            <p className="honeypot-date">{honeypot.eventDate}</p>
-                            <p className="total-member">
-                              참여인원 {honeypot.approvedCount + 1} / {honeypot.totalMember}
-                            </p>
+                          <div className="honeypot-index-info">
+                            <div className="top-info">
+                              <div className="region-info">{filteredHoneypots[index]?.region}</div>
+                              <div className="category-info">{filteredHoneypots[index]?.interestName}</div>
+                              <div className="honeypot-status">{filteredHoneypots[index]?.closureStatus}</div>
+                            </div>
+                            <p className="honeypot-title">{filteredHoneypots[index]?.honeypotTitle}</p>
+                            <div className="honeypot-schedule">
+                              <div>일정</div>
+                              <p className="honeypot-date">{filteredHoneypots[index]?.eventDate}</p>
+                              <p className="total-member">
+                                참여인원 {filteredHoneypots[index]?.approvedCount + 1} / {filteredHoneypots[index]?.totalMember}
+                              </p>
+                            </div>
+                            <p className="end-date">{filteredHoneypots[index]?.endDate} 까지 모집해요</p>
                           </div>
-                          <p className="end-date">{honeypot.endDate} 까지 모집해요</p>
-                        </div>
-                      </div>
-                    ))}
+                        </Link>
+                      )) : filteredHoneypots.map((honeypot, index) => (
+                        <Link key={index} className="one-honeypot-index"
+                        to={`/honeypot/detail/${filteredHoneypots[index]?.honeypotCode}`}>
+                            <div className="honeypot-index-poster">
+                              <img src={filteredHoneypots[index]?.poster} alt="포스터이미지" />
+                              <hr className="honeypot-dashed" />
+                            </div>
+                            <div className="honeypot-index-info">
+                              <div className="top-info">
+                                <div className="region-info">{filteredHoneypots[index]?.region}</div>
+                                <div className="category-info">{filteredHoneypots[index]?.interestName}</div>
+                                <div className="honeypot-status">{filteredHoneypots[index]?.closureStatus}</div>
+                              </div>
+                              <p className="honeypot-title">{filteredHoneypots[index]?.honeypotTitle}</p>
+                              <div className="honeypot-schedule">
+                                <div>일정</div>
+                                <p className="honeypot-date">{filteredHoneypots[index]?.eventDate}</p>
+                                <p className="total-member">
+                                  참여인원 {filteredHoneypots[index]?.approvedCount + 1} / {filteredHoneypots[index]?.totalMember}
+                                </p>
+                              </div>
+                              <p className="end-date">{filteredHoneypots[index]?.endDate} 까지 모집해요</p>
+                            </div>                            
+                          </Link>))}                           
+                    </div>
+                    <Link to={"/honeypot"} className={`${styles.hosting_btn} ${styles.moreView}`}>허니팟 더보기</Link>
                   </div>
                   }
                 </li>

--- a/src/pages/cultureInfo/CultureDetail.js
+++ b/src/pages/cultureInfo/CultureDetail.js
@@ -219,7 +219,7 @@ export default function CultureDetail(props) {
                   </div> 
                   : 
                   <div className={styles.honeypotListBox}>
-                    <div className={`honeypot-list-container ${styles.honeypotListCont}`}>
+                    <div className={`${styles.honeypotListCont} honeypot-list-container`}>
                       {filteredHoneypots.length > 6 ? [...Array(parseInt(6))].map((honeypot, index) => (
                       <Link key={index} className="one-honeypot-index"
                         to={`/honeypot/detail/${filteredHoneypots[index]?.honeypotCode}`}>

--- a/src/pages/cultureInfo/CultureInfo.module.css
+++ b/src/pages/cultureInfo/CultureInfo.module.css
@@ -199,7 +199,8 @@ li.right_filter .selected_filter {width: 128px;}
 .detail_null_box {height: 562px; text-align: center;}
 .detail_null_box p {padding-bottom: 20px; font-size: 20px; font-weight: var(--regular);}
 .honeypotListBox {display: flex; flex-direction: column; align-items: center;}
-.honeypotListCont {width: 100%; padding-bottom: 60px;}
+.honeypotListCont {width: 100%; padding:0; padding-bottom: 60px;}
+.honeypotListCont a {width: calc((100% - 40px) / 2);}
 .hosting_btn {display: inline-block; height: 48px; padding: 0 20px; font-size: 24px; font-weight: var(--semiBold); line-height: 48px; text-align: center; color: #ffffff; border-radius:48px; background-color: var(--main-color); transition: background-color 200ms ease-in-out; cursor: pointer;}
 .hosting_btn:hover {background-color: var(--point-color);}
 

--- a/src/pages/cultureInfo/CultureInfo.module.css
+++ b/src/pages/cultureInfo/CultureInfo.module.css
@@ -198,6 +198,8 @@ li.right_filter .selected_filter {width: 128px;}
 /* null */
 .detail_null_box {height: 562px; text-align: center;}
 .detail_null_box p {padding-bottom: 20px; font-size: 20px; font-weight: var(--regular);}
+.honeypotListBox {display: flex; flex-direction: column; align-items: center;}
+.honeypotListCont {width: 100%; padding-bottom: 60px;}
 .hosting_btn {display: inline-block; height: 48px; padding: 0 20px; font-size: 24px; font-weight: var(--semiBold); line-height: 48px; text-align: center; color: #ffffff; border-radius:48px; background-color: var(--main-color); transition: background-color 200ms ease-in-out; cursor: pointer;}
 .hosting_btn:hover {background-color: var(--point-color);}
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[FEATURE][CULTUREINFO][EARLYBIRD]

### 💡 작업동기
- 얼리버드 공연/전시 정보 및 해당 정보로 생성된 허니팟(소셜링)정보 REST Api 호출 및 연결하기

### 🔑 주요 변경사항
1. 공연/전시 정보 메인 페이지 - 얼리버드 section에 조회
2. 공연/전시 정보 상세 페이지 - 해당 허니팟 리스트 조회
3. 카테고리 필터링 기능 추가(얼리버드 포함)

### 🏞 스크린샷
### 얼리버드 상세 페이지 연결
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/73331620/a1b92080-0d41-4d52-90e3-b38a79d3ae92)

### 세부 카테고리 필터 기능 적용
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/73331620/4e6eea38-389a-4198-ac30-e25719fbcbe5)

### 해당 공연/전시 허니팟 정보 조회
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/73331620/d6641071-3d80-4a77-8110-6a35bbe7c136)
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/73331620/29d18619-a435-4dcd-bf7f-c610356b32f8)

### 관련 이슈
- #102 

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
