### PR TITLE
[FEATURE][MAIN][API]얼리버드 공연/전시 및 허니팟 REST Api 호출 및 연결하기

### DIFF
--- a/src/apis/cultureInfo/EarlyBirdApi.js
+++ b/src/apis/cultureInfo/EarlyBirdApi.js
@@ -4,7 +4,6 @@ export default function EarlyBirdInfoApi({setEarlyBirdInfo} = null, apiName, ear
 
   // 얼리버드 공연/전시 정보 모두 호출
   const selectAllEarlyBirdInfo = () => {
-    // axios.get('http://localhost:8080/cultureinfo/early')
     axios.get('/local-api/early')
       .then(response => {
         console.log('API Response All:', response.data); // 디버깅을 위한 로그

--- a/src/apis/main/honeypotByMainApi.js
+++ b/src/apis/main/honeypotByMainApi.js
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+export default function HoneypotByMainApi({setHoneypots}, {setFilteredHoneypots}) {
+    
+    async function fetchHoneypots() {
+        try {
+            const response = await axios.get('http://localhost:8081/honeypot/listandapproved');
+            console.log("리스폰스는:", response);
+            setHoneypots(response.data);       
+            const filteredHoneypot = response.data.sort((a,b) => {return Number(a.endDate) - Number(b.endDate)});
+            setFilteredHoneypots(filteredHoneypot); // 초기 필터링 설정 
+        } catch (error) {
+            console.error('Error 입니다 : ', error);
+        }
+    }
+    fetchHoneypots();
+}

--- a/src/components/cultureInfo/EarlySlide.js
+++ b/src/components/cultureInfo/EarlySlide.js
@@ -14,7 +14,7 @@ function NextBtn(props) {
 }
 
 function PrevBtn(props) {
-  const { className, style, onClick } = props;
+  const { className, onClick } = props;
   return (
     <>
       <span className={`${className} ${styles.prev_btn}`} onClick={onClick}><img src={`${process.env.PUBLIC_URL}/images/commons/icon_arrow_left_white.png`} alt="arrow left direction icon"/></span>

--- a/src/components/main/EarlyBanner.js
+++ b/src/components/main/EarlyBanner.js
@@ -14,7 +14,7 @@ function NextBtn(props) {
 }
 
 function PrevBtn(props) {
-  const { className, style, onClick } = props;
+  const { className, onClick } = props;
   return (
     <>
       <span className={`${className} ${mainStyle.prev_btn}`} onClick={onClick}><img src={`${process.env.PUBLIC_URL}/images/commons/icon_arrow_left_white.png`} alt="arrow left direction icon"/></span>
@@ -22,7 +22,41 @@ function PrevBtn(props) {
   );
 }
 
-export default function EarlyBanner() {
+export default function EarlyBanner({earlyBirdInfo}) {
+  // 오늘 날짜 데이터
+  const today = new Date();
+  console.log('earlyBirdInfo:', earlyBirdInfo);
+
+  function timer(targetDate) {
+    const now = new Date();
+      const endDate = new Date(targetDate);
+      const timeRemaining = endDate - now;
+   
+      if (timeRemaining <= 0) {                
+        console.log("종료");
+          return "종료";
+      }
+   
+      const days = Math.floor(timeRemaining / (1000 * 60 * 60 * 24));
+      const hours = Math.floor((timeRemaining % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+      const minutes = Math.floor((timeRemaining % (1000 * 60 * 60)) / (1000 * 60));
+
+      return `${days}일 ${hours}시간 ${minutes}분`;
+      // const seconds = Math.floor((timeRemaining % (1000 * 60)) / 1000);
+
+      // const timerText = document.querySelectorAll(`.${mainStyle.time_left}`);      
+        // timerText.forEach((timer) => {
+        //   timer.textContent = `${days}일 ${hours}시간 ${minutes}분`;
+        //   // timer.textContent = `${days}일 ${hours}시간 ${minutes}분 ${seconds}초`;
+        // })
+      // console.log(`${days}일 ${hours}시간 ${minutes}분 ${seconds}초`);
+  }
+   
+  // 타겟 날짜 설정 (예: 2023년 12월 31일 23:59:59)
+  // const targetDate = new Date('2023-12-31T23:59:59').getTime();
+   
+ 
+
   const settings = {
     infinite: true,
     speed: 500,
@@ -39,81 +73,51 @@ export default function EarlyBanner() {
   return (
     <div className={`slider-container ${mainStyle.common_slide}`}>
       <Slider {...settings}>
-        <div className={mainStyle.early_slide_list}>
-          <Link to="/cultureinfo/detail" className={mainStyle.flex_start}>
-            <div className={mainStyle.early_img}>
-              <img src="https://images.unsplash.com/photo-1514525253161-7a46d19cd819?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mzd8fGNvbmNlcnQlMjBwb3N0ZXJ8ZW58MHx8MHx8fDA%3D" alt="early bird info"/>
+      {earlyBirdInfo ? earlyBirdInfo.map((item, index) => {
+          // 날짜 형식 변경
+          function formatDate(date) {
+            var writtenDate = new Date(date),
+              month = '' + (writtenDate?.getMonth() + 1),
+              day = '' + writtenDate?.getDate(),
+              year = writtenDate?.getFullYear();
+
+            if (month.length < 2) 
+              month = '0' + month;
+            if (day.length < 2) 
+              day = '0' + day;
+
+            return [year, month, day].join('.');
+          }
+
+           // 1초마다 업데이트
+          // const timerSet = (time) => {
+          //   setInterval(() => {
+          //   timer(time);
+          // }, 1000);}
+
+          // timerSet(new Date(item.saleEndDate).getTime());
+          const targetTime = new Date(item.saleEndDate).getTime();
+
+          const title = item?.ebTitle.replaceAll('&lt;',`<`).replaceAll('&gt;',`>`).replaceAll("&#39;","'"); // 
+
+          return(
+            <div className={mainStyle.early_slide_list} key={index}>
+              <Link to={`/cultureinfo/detail/${item.earlyBirdCode}`} state={{ earlyCheck: true }} className={mainStyle.flex_start}>
+                <div className={mainStyle.early_img}>
+                  <img src={item.poster} alt="early bird info"/>
+                </div>
+                <div className={mainStyle.early_txt_box}>
+                  <p className={mainStyle.early_tit}>{title}</p>
+                  <p className={mainStyle.early_date}>{formatDate(item.saleStartDate, null)}&nbsp;~&nbsp;{formatDate(item.saleEndDate, null)}</p>
+                  <p className={mainStyle.early_place}>{item.place}</p>
+                  <span className={mainStyle.left_time_mark}>남은시간</span>
+                  <p className={mainStyle.time_left}>{timer(targetTime)}</p>
+                  <p className={mainStyle.early_end_date}>얼리버드 : {formatDate(item.saleEndDate, null)}&nbsp;<span>24:00</span>까지</p>
+                </div>
+              </Link>
             </div>
-            <div className={mainStyle.early_txt_box}>
-              <p className={mainStyle.early_tit}>서양 미술 800년展</p>
-              <p className={mainStyle.early_date}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-              <p className={mainStyle.early_place}>더현대서울 6층 ALT.1</p>
-              <span className={mainStyle.left_time_mark}>남은시간</span>
-              <p className={mainStyle.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
-              <p className={mainStyle.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
-            </div>
-          </Link>
-        </div>
-        <div className={mainStyle.early_slide_list}>
-          <Link to="/cultureinfo/detail" className={mainStyle.flex_start}>
-            <div className={mainStyle.early_img}>
-              <img src="https://images.unsplash.com/photo-1598387180437-80388ae0df12?q=80&w=3552&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="early bird info"/>
-            </div>
-            <div className={mainStyle.early_txt_box}>
-              <p className={mainStyle.early_tit}>서양 미술 800년展</p>
-              <p className={mainStyle.early_date}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-              <p className={mainStyle.early_place}>더현대서울 6층 ALT.1</p>
-              <span className={mainStyle.left_time_mark}>남은시간</span>
-              <p className={mainStyle.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
-              <p className={mainStyle.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
-            </div>
-          </Link>
-        </div>
-        <div className={mainStyle.early_slide_list}>
-          <Link to="/cultureinfo/detail" className={mainStyle.flex_start}>
-            <div className={mainStyle.early_img}>
-              <img src="https://plus.unsplash.com/premium_photo-1695636587294-5e7eba3e3b43?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8ZmVzdGl2YWwlMjBwb3N0ZXJ8ZW58MHx8MHx8fDA%3D" alt="early bird info"/>
-            </div>
-            <div className={mainStyle.early_txt_box}>
-              <p className={mainStyle.early_tit}>서양 미술 800년展</p>
-              <p className={mainStyle.early_date}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-              <p className={mainStyle.early_place}>더현대서울 6층 ALT.1</p>
-              <span className={mainStyle.left_time_mark}>남은시간</span>
-              <p className={mainStyle.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
-              <p className={mainStyle.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
-            </div>
-          </Link>
-        </div>
-        <div className={mainStyle.early_slide_list}>
-          <Link to="/cultureinfo/detail" className={mainStyle.flex_start}>
-            <div className={mainStyle.early_img}>
-              <img src="https://images.unsplash.com/photo-1580130544401-347c796dceec?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NHx8ZXhoaWJpdGlvbiUyMHBvc3RlcnxlbnwwfHwwfHx8MA%3D%3D" alt="early bird info"/>
-            </div>
-            <div className={mainStyle.early_txt_box}>
-              <p className={mainStyle.early_tit}>서양 미술 800년展</p>
-              <p className={mainStyle.early_date}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-              <p className={mainStyle.early_place}>더현대서울 6층 ALT.1</p>
-              <span className={mainStyle.left_time_mark}>남은시간</span>
-              <p className={mainStyle.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
-              <p className={mainStyle.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
-            </div>
-          </Link>
-        </div>
-        <div className={mainStyle.early_slide_list}>
-          <Link to="/cultureinfo/detail" className={mainStyle.flex_start}>
-            <div className={mainStyle.early_img}>
-              <img src="https://images.unsplash.com/photo-1530263131525-1c1d26feaa60?q=80&w=3542&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="early bird info"/>
-            </div>
-            <div className={mainStyle.early_txt_box}>
-              <p className={mainStyle.early_tit}>서양 미술 800년展</p>
-              <p className={mainStyle.early_date}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-              <p className={mainStyle.early_place}>더현대서울 6층 ALT.1</p>
-              <span className={mainStyle.left_time_mark}>남은시간</span>
-              <p className={mainStyle.time_left}><span>1일</span>&nbsp;<span>5시간</span>&nbsp;<span>36분</span>&nbsp;<span>12초</span></p>
-              <p className={mainStyle.early_end_date}>얼리버드 : 07.19&nbsp;<span>24:00</span>까지</p>
-            </div>
-          </Link>
-        </div>
+          );          
+        }) : <div>Loading중입니다.</div>}        
       </Slider>
     </div>
   );

--- a/src/components/main/HotBanner.js
+++ b/src/components/main/HotBanner.js
@@ -22,7 +22,7 @@ function PrevBtn(props) {
   );
 }
 
-export default function HotBanner() {
+export default function HotBanner({hotList}) {
   const settings = {
     infinite: true,
     speed: 500,
@@ -39,56 +39,33 @@ export default function HotBanner() {
   return (
     <div className={`slider-container ${mainStyle.hot_prf_box} ${mainStyle.common_slide}`}>
       <Slider {...settings}>
-        <div className={mainStyle.hot_prf_list}>
+      {hotList ? hotList.perforList.map((item, index) => {
+        // 공연 / 전시 start/endDate
+        const convertDateFormat = (stringDate, type) => {
+          let dateFormat = "";
+          const year = stringDate?.slice(0, 4);
+          const month = stringDate?.slice(4, 6);
+          const day = stringDate?.slice(6);
+          if(type == "rest"){
+            dateFormat = new Date(year+"-"+month+"-"+day); // 날짜 표시 형식
+          } else{
+            dateFormat = year+"."+month+"."+day; // 날짜 표시 형식
+          }              
+          return dateFormat;
+        }
+
+        const title = item?.title.replaceAll('&lt;',`<`).replaceAll('&gt;',`>`).replaceAll("&#39;","'");
+
+        return(<div className={mainStyle.hot_prf_list} key={index}>
           <Link to="/cultureinfo/detail">
-            <img src="https://images.unsplash.com/photo-1545264835-3e14e4dae383?q=80&w=2548&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="hot performance poster"/>
+            <img src={item.thumbnail} alt={`${title} poster`}/>
             <div className={mainStyle.hot_prf_txt}>
-              <p className={mainStyle.hot_tit}>서양 미술 800년展</p>
-              <p className={mainStyle.hot_place}>더 현대 서울 ALT.1</p>
-              <p className={mainStyle.hot_period}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
+              <p className={mainStyle.hot_tit}>{title}</p>
+              <p className={mainStyle.hot_place}>{item.place}</p>
+              <p className={mainStyle.hot_period}>{convertDateFormat(item.startDate, null)} ~ {convertDateFormat(item.endDate, null)}</p>
             </div>
           </Link>
-        </div>
-        <div className={mainStyle.hot_prf_list}>
-          <Link to="/cultureinfo/detail">
-            <img src="https://images.unsplash.com/photo-1571847140471-1d7766e825ea?q=80&w=3866&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="hot performance poster"/>
-            <div className={mainStyle.hot_prf_txt}>
-              <p className={mainStyle.hot_tit}>서양 미술 800년展</p>
-              <p className={mainStyle.hot_place}>더 현대 서울 ALT.1</p>
-              <p className={mainStyle.hot_period}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-            </div>
-          </Link>
-        </div>
-        <div className={mainStyle.hot_prf_list}>
-          <Link to="/cultureinfo/detail">
-            <img src="https://images.unsplash.com/photo-1625062833789-b0273c8a3f58?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MjB8fGNvbmNlcnQlMjBwb3N0ZXJ8ZW58MHx8MHx8fDA%3D" alt="hot performance poster"/>
-            <div className={mainStyle.hot_prf_txt}>
-              <p className={mainStyle.hot_tit}>서양 미술 800년展</p>
-              <p className={mainStyle.hot_place}>더 현대 서울 ALT.1</p>
-              <p className={mainStyle.hot_period}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-            </div>
-          </Link>
-        </div>     
-        <div className={mainStyle.hot_prf_list}>
-          <Link to="/cultureinfo/detail">
-            <img src="https://images.unsplash.com/photo-1569949237615-e2defbeb5d0a?q=80&w=1960&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="hot performance poster"/>
-            <div className={mainStyle.hot_prf_txt}>
-              <p className={mainStyle.hot_tit}>서양 미술 800년展</p>
-              <p className={mainStyle.hot_place}>더 현대 서울 ALT.1</p>
-              <p className={mainStyle.hot_period}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-            </div>
-          </Link>
-        </div>     
-        <div className={mainStyle.hot_prf_list}>
-          <Link to="/cultureinfo/detail">
-            <img src="https://images.unsplash.com/photo-1497911270199-1c552ee64aa4?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MzF8fGNvbmNlcnQlMjBwb3N0ZXJ8ZW58MHx8MHx8fDA%3D" alt="hot performance poster"/>
-            <div className={mainStyle.hot_prf_txt}>
-              <p className={mainStyle.hot_tit}>서양 미술 800년展</p>
-              <p className={mainStyle.hot_place}>더 현대 서울 ALT.1</p>
-              <p className={mainStyle.hot_period}>2024.08.05&nbsp;~&nbsp;2024.10.31</p>
-            </div>
-          </Link>
-        </div>     
+        </div>);}) : null}
       </Slider>
     </div>
   );

--- a/src/pages/cultureInfo/CultureInfo.js
+++ b/src/pages/cultureInfo/CultureInfo.js
@@ -34,8 +34,8 @@ export default function CultureInfo(props) {
 
   // 페이지네이션 상태 추가
   const [currentPage, setCurrentPage] = useState(1);
-  const cardItemsPerPage = 4;
-  const tableItemsPerPage = 4;
+  const cardItemsPerPage = 12;
+  const tableItemsPerPage = 15;
 
   // 장르 카테고리 선택 후, 등록순 / 지역 카테고리 선택
   // 장르 카테고리를 재설정할 경우, 하위 - 등록순 / 지역 카테고리 초기화

--- a/src/pages/main/Main.module.css
+++ b/src/pages/main/Main.module.css
@@ -41,10 +41,10 @@
 .hot_prf_sec {padding-top: 80px;}
 .hot_prf_box {padding: 40px 20px 0;}
 .hot_prf_box .hot_prf_list a {position: relative; display: block; padding: 20px 10px 0; margin: 0 10px!important; height: 360px; border:1px solid rgba(255, 183, 85, 0.2); border-radius:20px;background-color: var(--main-color); opacity: 1;}
-.hot_prf_list a img{width: 100%; height: 300px; margin:0 auto; object-fit: cover; object-position: top; border-radius:2px; box-shadow: 0 1px 2px rgba(255, 183, 85, 0.2);}
-.hot_prf_txt {position: absolute; bottom: 20px; left: 0; width: 100%; padding: 20px 10px 0; background-image: linear-gradient(to top, var(--main-color) 70%, rgba(255, 255, 255, 0));}
+.hot_prf_list a img{width: 100%; height: 300px; margin:0 auto; object-fit: cover; object-position: top; border-radius:8px; box-shadow: 0 1px 2px rgba(255, 183, 85, 0.2);}
+.hot_prf_txt {position: absolute; bottom: 20px; left: 0; width: 100%; height: 140px; padding: 20px 10px 0; background-image: linear-gradient(to top, var(--main-color) 70%, rgba(255, 255, 255, 0));}
 .hot_prf_txt p {font-size: 16px;}
-.hot_prf_txt .hot_tit {font-size: 20px; font-weight: var(--semiBold);}
+.hot_prf_txt .hot_tit {display: -webkit-box; padding-top: 20px; font-size: 20px; font-weight: var(--semiBold);-webkit-line-clamp: 2;-webkit-box-orient: vertical;overflow: hidden;line-height: 1.4;text-overflow: ellipsis;}
 
 /* 얼리버드 전시/공연 정보 */
 .early_sec {padding-top: 60px;}
@@ -64,4 +64,6 @@
 .early_end_date {font-weight: var(--medium);}
 
 /* 허니팟 리스트 */
-.honeypot_sec_box {height: 2000px;}
+.honeypot_sec_box {padding-bottom: 100px;}
+.honeypotCont {width: 100%; padding: 0;}
+.honeypotCont a {width: calc((100% - 40px) / 2);}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[FEATURE][MAIN][API]

### 💡 작업동기
- 메인페이지에 얼리버드 공연/전시 및 허니팟 REST Api 호출 및 연결하기

### 🔑 주요 변경사항
1. 메인 페이지 - HOT 공연/전시 section에 조회
2. 메인 페이지 - 얼리버드 section에 조회 
3. 메인 페이지 - 허니팟 section에 조회

### 🏞 스크린샷
### 메인 페이지 얼리버드 공연/전시 리스트 조회
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/73331620/ea109a02-d1bf-416a-aaf2-fb8e16df4972)

### 메인 페이지 -  Hot banner & 허니팟 리스트 조회
![screencapture-localhost-3001-main-2024-07-08-18_01_21](https://github.com/S-O-O-P/S-O-O-P-React/assets/73331620/af6d0c26-08f9-49e5-a25a-eefb65a7f1aa)

### 관련 이슈
- close #102 

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
