### PR TITLE
[FEATURE][CS] 고객센터 수정(+api 분리)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -133,7 +133,7 @@ export default function App() {
             <Route path='/help' element={<Cs />} /> {/* 고객 센터 */}
             <Route path='/faq' element={<Faq />} /> {/* 자주 찾는 질문 */}
             <Route path='/notice' element={<Notice />} /> {/* 공지사항 */}
-            <Route path='/inquiry' element={<Inquiry />} /> {/* 1:1문의 */}
+            <Route path='/inquiry' element={<Inquiry user={loggedInUser}/>} /> {/* 1:1문의 */}
             <Route path='/notice/:code' element={<NoticeDetailPage />} /> {/* 공지사항 상세페이지 */}
           </Route> {/* 레이아웃 클로즈 */}
         </Routes>

--- a/src/apis/serviceCenter/CsNotice.js
+++ b/src/apis/serviceCenter/CsNotice.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export const noticeAPI = async () => {
+    try {
+        const res = await axios.get('http://localhost:8081/help');
+        return res.data.mainNoticeList;
+    } catch (error) {
+        console.error("error", error);
+        return [];
+    }
+};

--- a/src/apis/serviceCenter/Inquiry.js
+++ b/src/apis/serviceCenter/Inquiry.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export const inquiryAPI = async (data) => {
+    try {
+        const response = await axios.post('http://localhost:8081/inquiry', data);
+        return response;
+    } catch (error) {
+        console.error("error", error);
+        throw error;
+    }
+};

--- a/src/apis/serviceCenter/Notice.js
+++ b/src/apis/serviceCenter/Notice.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export const noticesAPI = async () => {
+    try {
+        const response = await axios.get('http://localhost:8081/notice');
+        return response.data.mainNoticeList;
+    } catch (error) {
+        console.error('Failed to fetch notices', error);
+        throw error;
+    }
+};

--- a/src/apis/serviceCenter/NoticeDetailAPI.js
+++ b/src/apis/serviceCenter/NoticeDetailAPI.js
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+export const noticeAPI = async (code) => {
+    try {
+        const response = await axios.get(`http://localhost:8081/notice/${code}`);
+        return response.data.mainNoticeList;
+    } catch (error) {
+        console.error('공지사항 불러오기 실패', error);
+        throw error;
+    }
+};
+
+export const noticeFileAPI = async (id) => {
+    try {
+        const response = await axios.get(`http://localhost:8080/notice/${id}`);
+        return response.data.fileDTO;
+    } catch (error) {
+        console.error('공지사항 파일 불러오기 실패', error);
+        throw error;
+    }
+};

--- a/src/pages/serviceCenter/Cs.js
+++ b/src/pages/serviceCenter/Cs.js
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import style from './Cs.module.css';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 function CsPage() {
 
+    const navigater = useNavigate();
     const [notices, setNotices] = useState([]);
 
     useEffect(() => {
@@ -18,6 +20,10 @@ function CsPage() {
         }
         fetchNotice();
     }, []);
+
+    const inquiryBtn = () => {
+        navigater("/inquiry");
+    }
 
     return (
         <div className={style.wrapper}>
@@ -89,13 +95,13 @@ function CsPage() {
                             <p className={style.phoneInquiryText}>평일 9:00 ~ 18:00 | 주말 및 공휴일 휴무</p>
                         </div>
                     </div>
-                    <div className={style.inquiry}>
+                    <div className={style.inquiry} onClick={inquiryBtn}>
                         <img className={style.inquiryIcon} src="./images/commons/icon_inquiry_main_color.png" alt="1:1문의하기"></img>
                         <div>
-                            <a href="/inquiry" className={style.inquiryIinkButton}>
+                            <p className={style.inquiryIinkButton}>
                                 <p className={style.inquiryTitle}>1:1 문의하기</p>
                                 <img className={style.arrowIcon} src="./images/commons/icon_arrow.png" alt="화살표"></img>
-                            </a>
+                            </p>
                             <p className={style.inquiryText}>얼리벗에 궁금한 사항을 문의해 주세요.</p>
                             <p className={style.inquiryText}>최대한 빠른 시일 내에 답변해드리겠습니다.</p>
                         </div>

--- a/src/pages/serviceCenter/Cs.js
+++ b/src/pages/serviceCenter/Cs.js
@@ -1,28 +1,22 @@
 import { useEffect, useState } from 'react';
 import style from './Cs.module.css';
-import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { noticeAPI } from '../../apis/serviceCenter/CsNotice';
 
 function CsPage() {
-
-    const navigater = useNavigate();
+    const navigate = useNavigate();
     const [notices, setNotices] = useState([]);
 
     useEffect(() => {
-        async function fetchNotice() {
-            try {
-                const res = await axios.get('http://localhost:8081/help');
-                setNotices(res.data.mainNoticeList);
-                console.log(res.data.mainNoticeList);
-            } catch (error) {
-                console.error("error", error);
-            }
+        async function getNotices() {
+            const noticesData = await noticeAPI();
+            setNotices(noticesData);
         }
-        fetchNotice();
+        getNotices();
     }, []);
 
     const inquiryBtn = () => {
-        navigater("/inquiry");
+        navigate("/inquiry");
     }
 
     return (
@@ -81,7 +75,6 @@ function CsPage() {
                                 </ul>
                             ))}
                         </div>
-
                     </div>
                 </div>
                 <p className={style.helpMessage}>찾는 내용이 없을 경우 전화나 1:1문의 바랍니다.</p>
@@ -115,4 +108,4 @@ function CsPage() {
     )
 }
 
-export default CsPage
+export default CsPage;

--- a/src/pages/serviceCenter/Cs.module.css
+++ b/src/pages/serviceCenter/Cs.module.css
@@ -145,6 +145,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    cursor: pointer;
 }
 
 .inquiryIinkButton {

--- a/src/pages/serviceCenter/Faq.js
+++ b/src/pages/serviceCenter/Faq.js
@@ -131,6 +131,12 @@ function FaqPage() {
         console.log(search);
     };
 
+    const enterKey = (e) => {
+        if (e.key === "Enter") {
+            handleSubmit();
+        }
+    }
+
     const handleSelect = (e) => {
         setSelect(e.target.value);
     };
@@ -192,7 +198,7 @@ function FaqPage() {
                         <option value="기능">기능</option>
                         <option value="서비스">서비스</option>
                     </select>
-                    <input className={style.customInput} type="text" onChange={onChange} placeholder="검색어를 입력해주세요." />
+                    <input className={style.customInput} type="text" onChange={onChange} onKeyPress={enterKey} placeholder="검색어를 입력해주세요." />
                     <button className={style.submitBtn} onClick={() => { handleSubmit(); toggleFAQ(); }}>
                         <img src='/images/serviceCenter/search.png' alt='검색' />
                     </button>

--- a/src/pages/serviceCenter/Faq.module.css
+++ b/src/pages/serviceCenter/Faq.module.css
@@ -42,6 +42,7 @@
     -webkit-appearance: none;
     background: #fff calc(100% - 5px) center no-repeat url('/public/images/commons/icon_arrow_bottom_main_color.png');
     background-size: 25px;
+    cursor: pointer;
 }
 
 .customSelect:focus {
@@ -64,6 +65,7 @@
     position: absolute;
     right: 45px;
     top: 30px;
+    cursor: pointer;
 }
 
 /* ----- 자주 묻는 질문 ----- */

--- a/src/pages/serviceCenter/Inquiry.js
+++ b/src/pages/serviceCenter/Inquiry.js
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import style from './Inquiry.module.css';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import { inquiryAPI } from '../../apis/serviceCenter/Inquiry';
 
 function InquiryPage({ user }) {
 
-    const navigater = useNavigate();
+    const navigate = useNavigate();
     const [selected, setSelected] = useState("전체");
     const handleSelect = (e) => {
         setSelected(e.target.value);
@@ -26,7 +26,7 @@ function InquiryPage({ user }) {
     const [modalOpen, setModalOpen] = useState(false);
     const [writerModal, setWriterModal] = useState(false);
 
-    const handleSubmit = () => {
+    const handleSubmit = async () => {
         const today = new Date();
 
         if (title !== "" && content !== "") {
@@ -37,18 +37,16 @@ function InquiryPage({ user }) {
                 "userCode": user.userCode,
                 "inquiryDate": today,
                 "adminCode": 7
-            }
+            };
 
-            console.log("유형", selected);
-            console.log("제목:", title);
-            console.log("내용:", content);
-            console.log("userCode:", user.userCode);
             setModalOpen(true);
 
-            axios.post('http://localhost:8081/inquiry', data)
-                .then(response => {
-                    console.log("response", response);
-                })
+            try {
+                const response = await inquiryAPI(data);
+                console.log("response", response);
+            } catch (error) {
+                console.error("전송 실패", error);
+            }
 
         } else {
             setWriterModal(true);
@@ -60,7 +58,7 @@ function InquiryPage({ user }) {
     }
     const noticeBtn = () => {
         setModalOpen(false);
-        navigater("/notice");
+        navigate("/notice");
     }
 
     const [checkModal, setCheckModal] = useState(false);
@@ -69,7 +67,7 @@ function InquiryPage({ user }) {
         if (title !== "" || content !== "") {
             setCheckModal(true);
         } else {
-            navigater(-1);
+            navigate(-1);
         }
     }
 
@@ -150,7 +148,7 @@ function InquiryPage({ user }) {
                             <p className={style.modalContext}>작성 취소된 내용은 되돌릴 수 없습니다.</p>
                             <div className={style.modalButtonBox}>
                                 <button className={style.modalButton} onClick={() => setCheckModal(false)}>취소</button>
-                                <button className={style.modalButton} onClick={() => navigater(-1)}>확인</button>
+                                <button className={style.modalButton} onClick={() => navigate(-1)}>확인</button>
                             </div>
                         </div>
                     </div>

--- a/src/pages/serviceCenter/Inquiry.js
+++ b/src/pages/serviceCenter/Inquiry.js
@@ -1,12 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import style from './Inquiry.module.css';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 
-function InquiryPage() {
+function InquiryPage({ user }) {
 
     const navigater = useNavigate();
-
     const [selected, setSelected] = useState("전체");
     const handleSelect = (e) => {
         setSelected(e.target.value);
@@ -35,7 +34,7 @@ function InquiryPage() {
                 "category": selected,
                 "title": title,
                 "content": content,
-                "userCode": 1,  // 회원 정보로 수정 필요
+                "userCode": user.userCode,
                 "inquiryDate": today,
                 "adminCode": 7
             }
@@ -43,6 +42,7 @@ function InquiryPage() {
             console.log("유형", selected);
             console.log("제목:", title);
             console.log("내용:", content);
+            console.log("userCode:", user.userCode);
             setModalOpen(true);
 
             axios.post('http://localhost:8081/inquiry', data)
@@ -56,8 +56,11 @@ function InquiryPage() {
     };
 
     const closeBtn = () => {
-        setModalOpen(false);
         setWriterModal(false);
+    }
+    const noticeBtn = () => {
+        setModalOpen(false);
+        navigater("/notice");
     }
 
     const [checkModal, setCheckModal] = useState(false);
@@ -126,9 +129,7 @@ function InquiryPage() {
                             <img src='/images/serviceCenter/check.png' alt='확인' width={45} />
                             <p className={style.modalTitle}>1:1문의가 접수 되었습니다.</p>
                             <p className={style.modalContext}>문의 내용에 따라 답변이 늦어질 수 있습니다.</p>
-                            <a href="/help">
-                                <button className={style.modalButton} onClick={closeBtn}>확인</button>
-                            </a>
+                            <button className={style.modalButton} onClick={noticeBtn}>확인</button>
                         </div>
                     </div>
                 )}

--- a/src/pages/serviceCenter/Inquiry.module.css
+++ b/src/pages/serviceCenter/Inquiry.module.css
@@ -59,6 +59,7 @@
     -webkit-appearance: none;
     background: #fff calc(100% - 10px) center no-repeat url('/public/images/commons/icon_arrow_bottom_main_color.png');
     background-size: 25px;
+    cursor: pointer;
 }
 
 .customSelect:focus {
@@ -146,6 +147,7 @@
     font: var(--semiBold) 16px;
     color: var(--main-color);
     margin-right: 20px;
+    cursor: pointer;
 }
 
 .cancelButton:active {
@@ -161,6 +163,7 @@
     border-radius: 48px;
     font: var(--semiBold) 16px;
     color: #fff;
+    cursor: pointer;
 }
 
 .submitButton:active {
@@ -212,6 +215,7 @@
     color: #fff;
     font-size: 16px;
     font-weight: var(--regular);
+    cursor: pointer;
 }
 
 .modalButtonBox {

--- a/src/pages/serviceCenter/Notice.js
+++ b/src/pages/serviceCenter/Notice.js
@@ -1,11 +1,10 @@
 import { useEffect, useState } from 'react';
 import style from './Notice.module.css';
-import axios from 'axios';
+import { noticesAPI } from '../../apis/serviceCenter/Notice';
 import { useNavigate } from 'react-router-dom';
 
 function NoticePage() {
-
-    const navigater = useNavigate();
+    const navigate = useNavigate();
     const [notices, setNotices] = useState([]);
     const [search, setSearch] = useState('');
     const [select, setSelect] = useState('all');
@@ -15,20 +14,20 @@ function NoticePage() {
     const maxPageNumbers = 5;
 
     useEffect(() => {
-        async function fetchNotice() {
+        async function fetchNoticeData() {
             try {
-                const res = await axios.get('http://localhost:8081/notice');
-                setNotices(res.data.mainNoticeList);
-                setFilterNotice(res.data.mainNoticeList);
+                const noticeList = await noticesAPI();
+                setNotices(noticeList);
+                setFilterNotice(noticeList);
             } catch (error) {
-                console.error('공지사항 불러오기 실패.', error);
+                console.error('공지사항 불러오기 실패', error);
             }
         }
-        fetchNotice();
+        fetchNoticeData();
     }, []);
 
     const inquiryBtn = () => {
-        navigater("/inquiry");
+        navigate("/inquiry");
     }
 
     const onChange = (e) => {
@@ -39,7 +38,6 @@ function NoticePage() {
         const filtered = notices.filter(notice => {
             const matchCategory = select === '전체' || notice.category === select;
             const matchSearch = search === '' || notice.title.includes(search);
-
             return matchCategory && matchSearch;
         });
         setFilterNotice(filtered);

--- a/src/pages/serviceCenter/Notice.js
+++ b/src/pages/serviceCenter/Notice.js
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import style from './Notice.module.css';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 function NoticePage() {
 
+    const navigater = useNavigate();
     const [notices, setNotices] = useState([]);
     const [search, setSearch] = useState('');
     const [select, setSelect] = useState('all');
@@ -25,6 +27,10 @@ function NoticePage() {
         fetchNotice();
     }, []);
 
+    const inquiryBtn = () => {
+        navigater("/inquiry");
+    }
+
     const onChange = (e) => {
         setSearch(e.target.value);
     };
@@ -33,11 +39,18 @@ function NoticePage() {
         const filtered = notices.filter(notice => {
             const matchCategory = select === '전체' || notice.category === select;
             const matchSearch = search === '' || notice.title.includes(search);
+
             return matchCategory && matchSearch;
         });
         setFilterNotice(filtered);
         setCurrentPage(1);
     };
+
+    const enterKey = (e) => {
+        if (e.key === "Enter") {
+            handleSubmit();
+        }
+    }
 
     const handleSelect = (e) => {
         setSelect(e.target.value);
@@ -87,7 +100,7 @@ function NoticePage() {
                             <option value="공지사항">공지사항</option>
                             <option value="이벤트">이벤트</option>
                         </select>
-                        <input className={style.customInput} type="text" onChange={onChange} placeholder="검색어를 입력해주세요." />
+                        <input className={style.customInput} type="text" onChange={onChange} onKeyPress={enterKey} placeholder="검색어를 입력해주세요." />
                         <button className={style.submitBtn} onClick={handleSubmit}>
                             <img src='/images/serviceCenter/search.png' alt='검색' />
                         </button>
@@ -132,13 +145,13 @@ function NoticePage() {
                                 <p className={style.phoneInquiryText}>평일 9:00 ~ 18:00 | 주말 및 공휴일 휴무</p>
                             </div>
                         </div>
-                        <div className={style.inquiry}>
+                        <div className={style.inquiry} onClick={inquiryBtn}>
                             <img className={style.inquiryIcon} src="./images/commons/icon_inquiry_main_color.png" alt="1:1문의하기" />
                             <div>
-                                <a href="/inquiry" className={style.inquiryIinkButton}>
+                                <p className={style.inquiryIinkButton}>
                                     <p className={style.inquiryTitle}>1:1 문의하기</p>
                                     <img className={style.arrowIcon} src="./images/commons/icon_arrow.png" alt="화살표"></img>
-                                </a>
+                                </p>
                                 <p className={style.inquiryText}>얼리벗에 궁금한 사항을 문의해 주세요.</p>
                                 <p className={style.inquiryText}>최대한 빠른 시일 내에 답변해드리겠습니다.</p>
                             </div>

--- a/src/pages/serviceCenter/Notice.module.css
+++ b/src/pages/serviceCenter/Notice.module.css
@@ -42,6 +42,7 @@
     -webkit-appearance: none;
     background: #fff calc(100% - 5px) center no-repeat url('/public/images/commons/icon_arrow_bottom_main_color.png');
     background-size: 25px;
+    cursor: pointer;
 }
 
 .customSelect:focus {
@@ -64,6 +65,7 @@
     position: absolute;
     right: 45px;
     top: 30px;
+    cursor: pointer;
 }
 
 /* ----- 공지사항 ---- */
@@ -170,6 +172,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    cursor: pointer;
 }
 
 .inquiryIinkButton {

--- a/src/pages/serviceCenter/NoticeDetail.js
+++ b/src/pages/serviceCenter/NoticeDetail.js
@@ -1,61 +1,51 @@
-import axios from 'axios';
 import style from './NoticeDetail.module.css'
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { noticeAPI, noticeFileAPI } from '../../apis/serviceCenter/NoticeDetailAPI';
 
 function NoticeDetailPage() {
 
     const [notice, setNotice] = useState({});
-
+    const [file, setFile] = useState(null);
     const { code } = useParams();
 
     useEffect(() => {
-        async function fetchNotice() {
+        async function fetchData() {
             try {
-
-                const res = await axios.get(`http://localhost:8081/notice/${code}`);
-
-                console.log(res)
-                setNotice(res.data.mainNoticeList);
-                console.log(res.data.mainNoticeList);
+                const mainNotice = await noticeAPI(code);
+                setNotice(mainNotice);
             } catch (error) {
                 console.error('공지사항 불러오기 실패.', error);
             }
         }
-        fetchNotice();
-    }, []);
+        fetchData();
+    }, [code]);
 
-    const [file, setFile] = useState(null);
     useEffect(() => {
-        async function fetchNotice() {
+        async function fetchData() {
             try {
-                const id = code;
-                const res = await axios.get(`http://localhost:8080/notice/${id}`);
-                setFile(res.data.fileDTO);
-                console.log(res.data.fileDTO);
+                const fileDTO = await noticeFileAPI(code);
+                setFile(fileDTO);
             } catch (error) {
-                console.error('공지사항 불러오기 실패.', error);
+                console.error('파일 불러오기 실패.', error);
             }
         }
-        fetchNotice();
+        fetchData();
     }, [code]);
 
     return (
-
         <div className={style.wrapper}>
             <div className={style.contentBox}>
                 <p className={style.pageTitle}>공지사항</p>
-
                 <p className={style.noticeTitle}>{notice.title}</p>
                 <p className={style.noticeDate}>{notice.regDate}</p>
                 <hr className={style.hrLine} />
                 <p className={style.noticeContext}>{notice.content}</p>
                 <hr className={style.hrLine} />
-
                 {/* <img src={`http://localhost:8080/notice/image?name=${file.name}`} alt="preview image" /> */}
             </div>
         </div>
-    )
+    );
 }
 
 export default NoticeDetailPage;

--- a/src/pages/serviceCenter/NoticeDetail.js
+++ b/src/pages/serviceCenter/NoticeDetail.js
@@ -25,6 +25,21 @@ function NoticeDetailPage() {
         fetchNotice();
     }, []);
 
+    const [file, setFile] = useState(null);
+    useEffect(() => {
+        async function fetchNotice() {
+            try {
+                const id = code;
+                const res = await axios.get(`http://localhost:8080/notice/${id}`);
+                setFile(res.data.fileDTO);
+                console.log(res.data.fileDTO);
+            } catch (error) {
+                console.error('공지사항 불러오기 실패.', error);
+            }
+        }
+        fetchNotice();
+    }, [code]);
+
     return (
 
         <div className={style.wrapper}>
@@ -36,6 +51,8 @@ function NoticeDetailPage() {
                 <hr className={style.hrLine} />
                 <p className={style.noticeContext}>{notice.content}</p>
                 <hr className={style.hrLine} />
+
+                {/* <img src={`http://localhost:8080/notice/image?name=${file.name}`} alt="preview image" /> */}
             </div>
         </div>
     )


### PR DESCRIPTION
### 🔑 주요 변경사항
**1:1 문의** 
- 박스 전체 버튼으로(커서 - 포인터, 이동 useNavigate로변경)
- 로그인한 유저의 코드 받아서 전달

**공지사항**
- 검색 엔터로 가능

**api 분리**

### 🏞 스크린샷
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/157683303/90c30a42-f50d-48b4-aee6-4812a1b318de)
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/157683303/7b49d9e1-ac1e-444a-bede-5ab7ef6e577d)
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/157683303/3e6138f2-0e97-40d7-ae29-bf0dddf84981)
![image](https://github.com/S-O-O-P/S-O-O-P-React/assets/157683303/60a6e044-b9e0-45b9-a743-9b47400b96a2)

close #126
close #124 
