### PR TITLE
[REFACTOR][HEADER][MYPAGE] 프로필 사진 추가, 및 공연전시 API 복구

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -48,16 +48,16 @@ export default function App() {
     }
   }, [data]);
 
-  // useEffect(() => {
-  //   // seqList가 변경될 때마다 CultureDetailApi 호출
-  //   seqList.forEach(seq => {
-  //     CultureDetailApi({
-  //       setDetailData: detailData => {
-  //         setDetailDataList(prev => ({ ...prev, [seq]: detailData }));
-  //       }
-  //     }, seq);
-  //   });
-  // }, [seqList]);
+  useEffect(() => {
+    // seqList가 변경될 때마다 CultureDetailApi 호출
+    seqList.forEach(seq => {
+      CultureDetailApi({
+        setDetailData: detailData => {
+          setDetailDataList(prev => ({ ...prev, [seq]: detailData }));
+        }
+      }, seq);
+    });
+  }, [seqList]);
 
   // PublicRoute  = access 토큰이 있는 상태로 접근 불가 (예를 들면 로그인 페이지, 회원가입 페이지 등등)
   // PrivateRoute = access 토큰이 없는 경우 접근 불가 (예를 들면 회원가입 페이지, 마이페이지, 1:1 문의 등등)
@@ -111,6 +111,8 @@ export default function App() {
     }
   }, [decodedToken]);
 
+  console.log("앱JS 유저", loggedInUser);
+
   return (
     <>
       <GlobalStyles />
@@ -118,8 +120,8 @@ export default function App() {
         <ExpiredToken />
         <Routes>
           <Route element={<Layout user={loggedInUser} />}> {/* 레이아웃 오픈 */}
-            <Route path='/main' element={data ? <Main cultureList={JSON.stringify(data)} /> : <LoadingSpinner />} /> {/* 메인 */}
-            <Route index element={data ? <Main cultureList={JSON.stringify(data)} /> : <LoadingSpinner />} /> {/* 메인 */}
+            <Route path='/main' element={data ? <Main cultureList={JSON.stringify(data)} user={loggedInUser}/> : <LoadingSpinner />} /> {/* 메인 */}
+            <Route index element={data ? <Main cultureList={JSON.stringify(data)} user={loggedInUser}/> : <LoadingSpinner />} /> {/* 메인 */}
             <Route path='/login' element={ <LoginPage />}/> {/* 로그인 */}
             <Route path='/signup' element={<SignUpPage user={loggedInUser}/>} /> {/* 추가 정보 입력 */}
             <Route path="/cultureinfo" element={data ? <CultureInfo cultureList={JSON.stringify(data)} detailDataList={detailDataList}/> : <LoadingSpinner />}/> {/* 전시/공연 정보 */}

--- a/src/apis/CultureApi.js
+++ b/src/apis/CultureApi.js
@@ -125,28 +125,163 @@
 
   // return null; // JSX를 반환하지 않음
 
-  export default function CultureApi({ setData }) {
-  const url = 'https://raw.githubusercontent.com/S-O-O-P/S-O-O-P-DB/master/dummy.json'; // JSON 데이터 파일 URL
+  /** 🦝 무제한 더미 API 🦝 */
 
-  const xhr = new XMLHttpRequest();
-  xhr.open('GET', url, true);
+  // export default function CultureApi({ setData }) {
 
-  xhr.onload = function () {
-    if (xhr.status >= 200 && xhr.status < 300) {
-      const jsonData = JSON.parse(xhr.responseText); // JSON 데이터를 파싱
-      setData(jsonData.response.msgBody); // msgBody 안에 있는 데이터 설정
-      // console.log("from CultureApi : " + JSON.stringify(jsonData.response.msgBody)); // 데이터 확인 로그
-    } else {
-      console.error('Network response was not ok ' + xhr.statusText);
-    }
-  };
+  //   // 카운터 관련 함수들
+  //   const getApiCallCount = () => {
+  //     return parseInt(localStorage.getItem('apiCallCount') || '0');
+  //   };
+  
+  //   const incrementApiCallCount = () => {
+  //     const count = getApiCallCount() + 1;
+  //     localStorage.setItem('apiCallCount', count.toString());
+  //     return count;
+  //   };
+  
+  //   const resetCounterIfNewDay = () => {
+  //     const lastResetDate = localStorage.getItem('lastResetDate');
+  //     const today = new Date().toDateString();
+  //     if (lastResetDate !== today) {
+  //       localStorage.setItem('apiCallCount', '0');
+  //       localStorage.setItem('lastResetDate', today);
+  //     }
+  //   };
+  
+  //   const makeApiCall = () => {
+  //     const url = 'https://raw.githubusercontent.com/S-O-O-P/S-O-O-P-DB/master/dummy.json'; // JSON 데이터 파일 URL
+  
+  //     const xhr = new XMLHttpRequest();
+  //     xhr.open('GET', url, true);
+  
+  //     // API 호출 전 카운터 체크 및 증가
+  //     resetCounterIfNewDay();
+  //     const currentCount = incrementApiCallCount();
+  //     console.log(`API Call Start: ${url}, Count: ${currentCount}`);
+  
+  //     xhr.onload = function () {
+  //       console.log(`API Call End: ${url}, Status: ${xhr.status}, Count: ${currentCount}`);
+  
+  //       if (xhr.status >= 200 && xhr.status < 300) {
+  //         const jsonData = JSON.parse(xhr.responseText); // JSON 데이터를 파싱
+  //         setData(jsonData.response.msgBody); // msgBody 안에 있는 데이터 설정
+  //         // console.log("from CultureApi : " + JSON.stringify(jsonData.response.msgBody)); // 데이터 확인 로그
+  //       } else {
+  //         console.error('Network response was not ok ' + xhr.statusText);
+  //       }
+  //     };
+  
+  //     xhr.onerror = function () {
+  //       console.error('XMLHttpRequest failed');
+  //     };
+  
+  //     xhr.send();
+  //   };
+  
+  //   // 필요한 곳에서 makeApiCall 함수를 호출하면 됩니다.
+  //   makeApiCall();
+  
+  //   return null;
+  // };
 
-  xhr.onerror = function () {
-    console.error('XMLHttpRequest failed');
-  };
 
-  xhr.send();
+/** ❗ 최종으로 써야할 API ?❗*/
 
-  return null;
+export default function CultureApi({ setData }) {
+    
+  // 카운터 관련 함수들
+  const getApiCallCount = () => {
+   return parseInt(localStorage.getItem('apiCallCount') || '0');
+ };
 
+ const incrementApiCallCount = () => {
+   const count = getApiCallCount() + 1;
+   localStorage.setItem('apiCallCount', count.toString());
+   return count;
+ };
+
+ const resetCounterIfNewDay = () => {
+   const lastResetDate = localStorage.getItem('lastResetDate');
+   const today = new Date().toDateString();
+   if (lastResetDate !== today) {
+     localStorage.setItem('apiCallCount', '0');
+     localStorage.setItem('lastResetDate', today);
+   }
+ };
+ 
+ const serviceKey = '8/QFvrhFxUkbFccDXVjo2OKIiDWufUA8v2jGrIaDSWRqL499Gznzk7NYdHxvIoOvbJes6wYSeXMEgXHhyUxS9g=='; // 서비스 인증키
+   const xhr = new XMLHttpRequest(); //XMLHttpRequest는 비동기로 작동
+   const url = '/api/openapi/rest/publicperformancedisplays/realm'; //기간별 공연/전시 정보 목록 조회 요청 url
+   const queryParams = new URLSearchParams({ // 조회시 요청 parameters
+     serviceKey: serviceKey,
+     keyword: '',
+     //sortStdr: '3', // 1 : 등록일 / 2 :   / 3 : 지역
+     ComMsgHeader: '',
+     RequestTime: '20240701:23003422', // 요청 기간 
+     CallBackURI: '',
+     MsgBody: '',
+     cPage: '1',
+     rows: '50', // 1페이지에 불러올 데이터 갯수
+     from: '20240714', // 시작일
+     to: '20240715' // 종료일
+   });
+
+   xhr.open('GET', `${url}?${queryParams.toString()}`, true); // get 요청
+
+   // API 호출 전 카운터 체크 및 증가
+   resetCounterIfNewDay();
+   const currentCount = incrementApiCallCount();
+   console.log(`API Call Start: ${url}, Count: ${currentCount}`);
+
+   xhr.onload = function () { // 요청이 완료되었을 때 실행될 함수
+     console.log(`API Call End: ${url}, Status: ${xhr.status}, Count: ${currentCount}`);
+
+     if (xhr.status >= 200 && xhr.status < 300) { // HTTP 상태 코드 확인하여 요청 성공 여부 판단
+       const xmlText = xhr.responseText; // response로 전달받은 xml 데이터를 텍스트 형식으로 저장
+       const parser = new DOMParser(); // XML 문자열을 파싱하기 위해 DOMParser 객체를 생성
+       const xmlDom = parser.parseFromString(xmlText, 'application/xml'); // XML 문자열을 XML DOM 객체로 변환
+       const jsonData = xmlToJson(xmlDom); // XML 데이터를 JSON 형식으로 변환
+       setData(jsonData.response.msgBody[0]); // App.js에서 전달받은 setData 함수를 호출하여 데이터 설정
+       console.log("from CultureApi : "+jsonData.response.msgBody[0]);
+     } else {
+       // 오류 처리
+       console.error('Network response was not ok ' + xhr.statusText);
+     }
+   };
+   xhr.onerror = function () {
+     // 네트워크 오류 처리
+     console.error('XMLHttpRequest failed');
+   };
+   xhr.send();
+ const xmlToJson = (xml) => {
+   const result = {};
+   const root = xml.documentElement;
+   const parseNode = (node) => {
+     const obj = {};
+     if (node.nodeType === Node.ELEMENT_NODE && node.attributes.length > 0) {
+       for (const attr of node.attributes) {
+         obj[attr.nodeName] = attr.nodeValue;
+       }
+     }
+     if (node.hasChildNodes()) {
+       for (const child of node.childNodes) {
+         if (child.nodeType === Node.ELEMENT_NODE) {
+           if (child.childNodes.length === 1 && child.firstChild.nodeType === Node.TEXT_NODE) {
+             obj[child.nodeName] = child.textContent.trim();
+           } else {
+             if (!obj[child.nodeName]) {
+               obj[child.nodeName] = [];
+             }
+             obj[child.nodeName].push(parseNode(child));
+           }
+         }
+       }
+     }
+     return obj;
+   };
+   result[root.nodeName] = parseNode(root);
+   return result;
+ };
+ return null; // JSX를 반환하지 않음
 };

--- a/src/apis/CultureDetailApi.js
+++ b/src/apis/CultureDetailApi.js
@@ -1,84 +1,85 @@
-// export default function CultureDetailApi({setDetailData}, seq) {
-//   console.log("seq from CultureDetailApi : " + seq);
-//   const serviceKey = '8/QFvrhFxUkbFccDXVjo2OKIiDWufUA8v2jGrIaDSWRqL499Gznzk7NYdHxvIoOvbJes6wYSeXMEgXHhyUxS9g=='; // 서비스 인증키
-//     const xhr = new XMLHttpRequest(); //XMLHttpRequest는 비동기로 작동
-//     const url = '/api/openapi/rest/publicperformancedisplays/d/'; // 공연/전시 정보 상세 조회 요청 url
-//     const queryParams = new URLSearchParams({ // 조회시 요청 parameters
-//       serviceKey: serviceKey,
-//       ComMsgHeader: '',
-//       RequestTime: '20240701:23003422', // 요청 기간 
-//       CallBackURI: '',
-//       MsgBody: '',
-//       seq: seq,
-//     });
-
-//     xhr.open('GET', `${url}?${queryParams.toString()}`, true); // get 요청
-
-//     xhr.onload = function () { // 요청이 완료되었을 때 실행될 함수
-//       if (xhr.status >= 200 && xhr.status < 300) { // HTTP 상태 코드 확인하여 요청 성공 여부 판단
-//         const xmlText = xhr.responseText; // response로 전달받은 xml 데이터를 텍스트 형식으로 저장
-//         const parser = new DOMParser(); // XML 문자열을 파싱하기 위해 DOMParser 객체를 생성
-//         const xmlDom = parser.parseFromString(xmlText, 'application/xml'); // XML 문자열을 XML DOM 객체로 변환
-//         const jsonData = xmlToJson(xmlDom); // XML 데이터를 JSON 형식으로 변환
-//         // setDetailData(jsonData.response.msgBody.msgBody[0].perforInfo[0]); // App.js에서 전달받은 setDetailData 함수를 호출하여 데이터 설정
-//         // console.log("from CultureApi : "+JSON.stringify(jsonData.response.msgBody[0].perforInfo[0]));
-//         //console.log("JSON Data: ", JSON.stringify(jsonData)); // JSON 데이터 구조를 로그로 확인
-      
-//         const perforInfo = jsonData?.response?.msgBody?.[0]?.perforInfo?.[0];
-//         if (perforInfo) {
-//           setDetailData(perforInfo); // CultureDetail.js에서 전달받은 setDetailData 함수를 호출하여 데이터 설정
-//           //console.log("from CultureApi : " + JSON.stringify(perforInfo));
-//         } else {
-//           //console.error('Expected data structure is missing: ', JSON.stringify(jsonData));
-//         }
-//       } else {
-//         // 오류 처리
-//         console.error('Network response was not ok ' + xhr.statusText);
-//       }
-//     };
-
-//     xhr.onerror = function () {
-//       // 네트워크 오류 처리
-//       console.error('XMLHttpRequest failed');
-//     };
-
-//     xhr.send();
-
-//   const xmlToJson = (xml) => {
-//     const result = {};
-//     const root = xml.documentElement;
-
-//     const parseNode = (node) => {
-//       const obj = {};
-
-//       if (node.nodeType === Node.ELEMENT_NODE && node.attributes.length > 0) {
-//         for (const attr of node.attributes) {
-//           obj[attr.nodeName] = attr.nodeValue;
-//         }
-//       }
-
-//       if (node.hasChildNodes()) {
-//         for (const child of node.childNodes) {
-//           if (child.nodeType === Node.ELEMENT_NODE) {
-//             if (child.childNodes.length === 1 && child.firstChild.nodeType === Node.TEXT_NODE) {
-//               obj[child.nodeName] = child.textContent.trim();
-//             } else {
-//               if (!obj[child.nodeName]) {
-//                 obj[child.nodeName] = [];
-//               }
-//               obj[child.nodeName].push(parseNode(child));
-//             }
-//           }
-//         }
-//       }
-
-//       return obj;
-//     };
-
-//     result[root.nodeName] = parseNode(root);
-//     return result;
-//   };
-
-//   return null; // JSX를 반환하지 않음
-// };
-
+export default function CultureDetailApi({setDetailData}, seq) {
+    console.log("seq from CultureDetailApi : " + seq);
+    const serviceKey = '8/QFvrhFxUkbFccDXVjo2OKIiDWufUA8v2jGrIaDSWRqL499Gznzk7NYdHxvIoOvbJes6wYSeXMEgXHhyUxS9g=='; // 서비스 인증키
+      const xhr = new XMLHttpRequest(); //XMLHttpRequest는 비동기로 작동
+      const url = '/api/openapi/rest/publicperformancedisplays/d/'; // 공연/전시 정보 상세 조회 요청 url
+      const queryParams = new URLSearchParams({ // 조회시 요청 parameters
+        serviceKey: serviceKey,
+        ComMsgHeader: '',
+        RequestTime: '20240701:23003422', // 요청 기간 
+        CallBackURI: '',
+        MsgBody: '',
+        seq: seq,
+      });
+  
+      xhr.open('GET', `${url}?${queryParams.toString()}`, true); // get 요청
+  
+      xhr.onload = function () { // 요청이 완료되었을 때 실행될 함수
+        if (xhr.status >= 200 && xhr.status < 300) { // HTTP 상태 코드 확인하여 요청 성공 여부 판단
+          const xmlText = xhr.responseText; // response로 전달받은 xml 데이터를 텍스트 형식으로 저장
+          const parser = new DOMParser(); // XML 문자열을 파싱하기 위해 DOMParser 객체를 생성
+          const xmlDom = parser.parseFromString(xmlText, 'application/xml'); // XML 문자열을 XML DOM 객체로 변환
+          const jsonData = xmlToJson(xmlDom); // XML 데이터를 JSON 형식으로 변환
+          // setDetailData(jsonData.response.msgBody.msgBody[0].perforInfo[0]); // App.js에서 전달받은 setDetailData 함수를 호출하여 데이터 설정
+          // console.log("from CultureApi : "+JSON.stringify(jsonData.response.msgBody[0].perforInfo[0]));
+          //console.log("JSON Data: ", JSON.stringify(jsonData)); // JSON 데이터 구조를 로그로 확인
+        
+          const perforInfo = jsonData?.response?.msgBody?.[0]?.perforInfo?.[0];
+          if (perforInfo) {
+            setDetailData(perforInfo); // CultureDetail.js에서 전달받은 setDetailData 함수를 호출하여 데이터 설정
+            //console.log("from CultureApi : " + JSON.stringify(perforInfo));
+          } else {
+            //console.error('Expected data structure is missing: ', JSON.stringify(jsonData));
+          }
+        } else {
+          // 오류 처리
+          console.error('Network response was not ok ' + xhr.statusText);
+        }
+      };
+  
+      xhr.onerror = function () {
+        // 네트워크 오류 처리
+        console.error('XMLHttpRequest failed');
+      };
+  
+      xhr.send();
+  
+    const xmlToJson = (xml) => {
+      const result = {};
+      const root = xml.documentElement;
+  
+      const parseNode = (node) => {
+        const obj = {};
+  
+        if (node.nodeType === Node.ELEMENT_NODE && node.attributes.length > 0) {
+          for (const attr of node.attributes) {
+            obj[attr.nodeName] = attr.nodeValue;
+          }
+        }
+  
+        if (node.hasChildNodes()) {
+          for (const child of node.childNodes) {
+            if (child.nodeType === Node.ELEMENT_NODE) {
+              if (child.childNodes.length === 1 && child.firstChild.nodeType === Node.TEXT_NODE) {
+                obj[child.nodeName] = child.textContent.trim();
+              } else {
+                if (!obj[child.nodeName]) {
+                  obj[child.nodeName] = [];
+                }
+                obj[child.nodeName].push(parseNode(child));
+              }
+            }
+          }
+        }
+  
+        return obj;
+      };
+  
+      result[root.nodeName] = parseNode(root);
+      return result;
+    };
+  
+    return null; // JSX를 반환하지 않음
+  };
+  
+  

--- a/src/components/commons/Header.css
+++ b/src/components/commons/Header.css
@@ -42,18 +42,26 @@
   cursor: pointer;
 }
 
+.go-to-mypage {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
 .mypage-btn {
   width: 40px;
   height: 40px;
+  border-radius: 50%;
+  border: 2px solid var(--main-color);
   margin-left: 15px;
-  cursor: pointer;
 }
 
 .mypage-btn:hover {
   width: 40px;
   height: 40px;
+  border-radius: 50%;
+  border: 2px solid var(--main-color);
   margin-left: 15px;
-  cursor: pointer;
 }
 
 .header-logo { 

--- a/src/components/commons/Header.js
+++ b/src/components/commons/Header.js
@@ -63,8 +63,10 @@ function Header({user}) {
         </nav>
         {accessToken ? (
           <>
-            <a href='/mypage' ><li className='nickName'>{loggedInUser.nickname} 님</li></a>
-            <a href='/mypage'><li><img className='mypage-btn' src={`${process.env.PUBLIC_URL}/images/commons/icon_mypage_colored.png`} alt="MYPAGE"/></li></a>
+            <div className='go-to-mypage' onClick={() => {navigate('/mypage')}}>
+              <li className='nickName'>{loggedInUser.nickname} 님</li>
+              <li><img className='mypage-btn' src={loggedInUser.profilePic} alt="MYPAGE"/></li>
+            </div>
             <li><img className='logout-btn' onClick={handleLogout} src={`${process.env.PUBLIC_URL}/images/commons/icon_logout_colored.png`} alt='LOGOUT'/></li>
           </>
         ) : (

--- a/src/components/mypage/EditProfile.js
+++ b/src/components/mypage/EditProfile.js
@@ -119,7 +119,6 @@ function EditProfile({ loggedInUser, onProfileUpdate }) {
             setShowConfirmModal(true);
             if (onProfileUpdate) {
                 onProfileUpdate(response.data.results.updateProflie);
-                window.location.reload();
             }
         } catch (error) {
             console.error("프로필 업데이트 실패:", error.response ? error.response.data : error.message);

--- a/src/components/mypage/EditProfile.js
+++ b/src/components/mypage/EditProfile.js
@@ -119,6 +119,7 @@ function EditProfile({ loggedInUser, onProfileUpdate }) {
             setShowConfirmModal(true);
             if (onProfileUpdate) {
                 onProfileUpdate(response.data.results.updateProflie);
+                window.location.reload();
             }
         } catch (error) {
             console.error("프로필 업데이트 실패:", error.response ? error.response.data : error.message);

--- a/src/pages/main/Main.js
+++ b/src/pages/main/Main.js
@@ -7,6 +7,7 @@ import EarlyBirdInfoApi from '../../apis/cultureInfo/EarlyBirdApi';
 import EarlyBanner from '../../components/main/EarlyBanner';
 import HoneypotByMainApi from '../../apis/main/honeypotByMainApi';
 
+
 export default function Main(props) {
   const [cultureList, setCultureList] = useState([]);
   const [earlyBirdInfo, setEarlyBirdInfo] = useState([]); // 얼리버드 리스트
@@ -15,6 +16,9 @@ export default function Main(props) {
   const [filteredHoneypots, setFilteredHoneypots] = useState([]); // 필터링된 허니팟 데이터
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
+
+  console.log("쁘롭스", props.user);
+
 
   //app.js에서 전달받은 api정보 state 저장
   useEffect(
@@ -53,7 +57,7 @@ export default function Main(props) {
       document.querySelector(".header-logo").setAttribute('src', 'images/commons/logo_white.png');
       if(document.querySelector(".mypage-btn")){
         //mypage-btn
-        document.querySelector(".mypage-btn").setAttribute('src', 'images/commons/icon_mypage_white.png');
+        document.querySelector(".mypage-btn").setAttribute('src', `${props.user.profilePic}` || 'images/commons/icon_mypage_white.png');
         document.querySelector(".logout-btn").setAttribute('src', 'images/commons/icon_logout_white.png');
         document.querySelector(".nickName").style.color = '#ffffff';
       }
@@ -63,7 +67,7 @@ export default function Main(props) {
           document.querySelector(".header-logo").setAttribute('src', 'images/commons/logo.png');
           if(document.querySelector(".mypage-btn")){
             //mypage-btn
-            document.querySelector(".mypage-btn").setAttribute('src', 'images/commons/icon_mypage_colored.png');
+            document.querySelector(".mypage-btn").setAttribute('src', `${props.user.profilePic}` || 'images/commons/icon_mypage_colored.png');
             document.querySelector(".logout-btn").setAttribute('src', 'images/commons/icon_logout_colored.png');
             document.querySelector(".nickName").style.color = '#282A29';
           }
@@ -72,7 +76,7 @@ export default function Main(props) {
           document.querySelector(".header-logo").setAttribute('src', 'images/commons/logo_white.png');
           if(document.querySelector(".mypage-btn")){
             //mypage-btn
-            document.querySelector(".mypage-btn").setAttribute('src', 'images/commons/icon_mypage_white.png');
+            document.querySelector(".mypage-btn").setAttribute('src', `${props.user.profilePic}` || 'images/commons/icon_mypage_white.png');
             document.querySelector(".logout-btn").setAttribute('src', 'images/commons/icon_logout_white.png');
             document.querySelector(".nickName").style.color = '#ffffff';
           }
@@ -87,7 +91,7 @@ export default function Main(props) {
         document.querySelector(".header-logo").setAttribute('src', `${process.env.PUBLIC_URL}/images/commons/logo.png`);
         if(document.querySelector(".mypage-btn")){
           //mypage-btn
-          document.querySelector(".mypage-btn").setAttribute('src', `${process.env.PUBLIC_URL}/images/commons/icon_mypage_colored.png`);
+          document.querySelector(".mypage-btn").setAttribute('src', `${props.user.profilePic}` || `${process.env.PUBLIC_URL}/images/commons/icon_mypage_colored.png`);
           document.querySelector(".logout-btn").setAttribute('src', `${process.env.PUBLIC_URL}/images/commons/icon_logout_colored.png`);
           document.querySelector(".nickName").style.color = '#282A29';
         }

--- a/src/pages/mypage/MyPage.js
+++ b/src/pages/mypage/MyPage.js
@@ -110,6 +110,7 @@ const MyPage = ({user}) => {
                     ...prevUser,
                     profilePic: downloadURL
                 }));
+                window.location.reload();
                 
             } catch (error) {
                 console.error('프로필사진 변경 실패:', error);


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[REFACTOR][HEADER][MYPAGE] 

### 💡 작업동기
- 공연 전시 API 원상복구(기존으로 교체)
- API 호출 누수 제거
- 로그인 시 헤더에 프로필 사진 적용(아이콘 -> 접속자의 프로필사진)

### 🔑 주요 변경사항
-  header a태그 -> NavLink 사용
- 프로필 사진 수정 시 헤더에 반영 되도록 reload (프로필사진 업데이트)
- 기존 공연전시 API 호출 완료

### 🏞 스크린샷
추가 작업 이슈로 인해 다음 풀 리퀘시 프로필 사진 부분 반영
![image](https://github.com/user-attachments/assets/60748455-f390-4e2f-a9f9-ed2b214e56e8)
![image](https://github.com/user-attachments/assets/302adcc3-601d-41ca-9d7b-13f6a5d21fa4)


### 관련 이슈
- 프로필 사진 수정 후에 이슈 클로즈 예정
- #130 

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
