### PR TITLE
[REFACTOR][EDITPROFILE] 헤더 프로필사진 반영 확인

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -96,18 +96,10 @@ export default function App() {
   // }, [checkLoginUser]);
 
   const { decodedToken, accessToken } = useDecodeJwtResponse();
-  const [role, setRole] = useState(null); 
-  const [signupPlatform, setSignupPlatform] = useState(null);
-  const [userCode, setUserCode] = useState(null);
 
   useEffect(() => {
-    if (decodedToken && decodedToken.userCode) {
-      setUserCode(decodedToken.userCode);
-      setRole(decodedToken.role);
-      setSignupPlatform(decodedToken.signupPlatform);
-      setLoggedInUser(decodedToken)
-    } else {
-      const decodedToken = null;
+    if (decodedToken) {
+      setLoggedInUser(decodedToken);
     }
   }, [decodedToken]);
 

--- a/src/components/mypage/EditProfile.js
+++ b/src/components/mypage/EditProfile.js
@@ -116,10 +116,19 @@ function EditProfile({ loggedInUser, onProfileUpdate }) {
     
         try {
             const response = await axios.put(`http://localhost:8081/mypage/${loggedInUser.userCode}`, updateData);
-            setShowConfirmModal(true);
-            if (onProfileUpdate) {
-                onProfileUpdate(response.data.results.updateProflie);
+            
+            console.log("서버 응답:", response.data); // 서버 응답 로깅
+
+            if (response.data && response.data.results && response.data.results.updateProflie) {
+                if (onProfileUpdate) {
+                    onProfileUpdate(response.data.results.updateProflie);
+                }
+                setShowConfirmModal(true); // 항상 모달을 표시합니다.
+            } else {
+                console.error("서버 응답에 예상된 데이터가 없습니다.");
+                alert("프로필 업데이트에 문제가 발생했습니다. 다시 시도해주세요.");
             }
+            
         } catch (error) {
             console.error("프로필 업데이트 실패:", error.response ? error.response.data : error.message);
             alert("프로필 업데이트에 실패했습니다. 다시 시도해주세요.");

--- a/src/pages/main/Main.js
+++ b/src/pages/main/Main.js
@@ -17,7 +17,7 @@ export default function Main(props) {
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
 
-  console.log("쁘롭스", props.user);
+  console.log("메인페이지유저정보", props.user);
 
 
   //app.js에서 전달받은 api정보 state 저장
@@ -57,7 +57,7 @@ export default function Main(props) {
       document.querySelector(".header-logo").setAttribute('src', 'images/commons/logo_white.png');
       if(document.querySelector(".mypage-btn")){
         //mypage-btn
-        document.querySelector(".mypage-btn").setAttribute('src', `${props.user.profilePic}` || 'images/commons/icon_mypage_white.png');
+        document.querySelector(".mypage-btn").setAttribute('src', props.user.profilePic || 'images/commons/icon_mypage_white.png');
         document.querySelector(".logout-btn").setAttribute('src', 'images/commons/icon_logout_white.png');
         document.querySelector(".nickName").style.color = '#ffffff';
       }
@@ -67,7 +67,7 @@ export default function Main(props) {
           document.querySelector(".header-logo").setAttribute('src', 'images/commons/logo.png');
           if(document.querySelector(".mypage-btn")){
             //mypage-btn
-            document.querySelector(".mypage-btn").setAttribute('src', `${props.user.profilePic}` || 'images/commons/icon_mypage_colored.png');
+            document.querySelector(".mypage-btn").setAttribute('src', props.user.profilePic || 'images/commons/icon_mypage_colored.png');
             document.querySelector(".logout-btn").setAttribute('src', 'images/commons/icon_logout_colored.png');
             document.querySelector(".nickName").style.color = '#282A29';
           }
@@ -76,7 +76,7 @@ export default function Main(props) {
           document.querySelector(".header-logo").setAttribute('src', 'images/commons/logo_white.png');
           if(document.querySelector(".mypage-btn")){
             //mypage-btn
-            document.querySelector(".mypage-btn").setAttribute('src', `${props.user.profilePic}` || 'images/commons/icon_mypage_white.png');
+            document.querySelector(".mypage-btn").setAttribute('src', props.user.profilePic || 'images/commons/icon_mypage_white.png');
             document.querySelector(".logout-btn").setAttribute('src', 'images/commons/icon_logout_white.png');
             document.querySelector(".nickName").style.color = '#ffffff';
           }
@@ -91,7 +91,7 @@ export default function Main(props) {
         document.querySelector(".header-logo").setAttribute('src', `${process.env.PUBLIC_URL}/images/commons/logo.png`);
         if(document.querySelector(".mypage-btn")){
           //mypage-btn
-          document.querySelector(".mypage-btn").setAttribute('src', `${props.user.profilePic}` || `${process.env.PUBLIC_URL}/images/commons/icon_mypage_colored.png`);
+          document.querySelector(".mypage-btn").setAttribute('src', props.user.profilePic || `${process.env.PUBLIC_URL}/images/commons/icon_mypage_colored.png`);
           document.querySelector(".logout-btn").setAttribute('src', `${process.env.PUBLIC_URL}/images/commons/icon_logout_colored.png`);
           document.querySelector(".nickName").style.color = '#282A29';
         }

--- a/src/pages/mypage/MyPage.js
+++ b/src/pages/mypage/MyPage.js
@@ -83,6 +83,44 @@ const MyPage = ({user}) => {
         });
     };
 
+    // getCookie 함수 정의
+    function getCookie(name) {
+        const value = `; ${document.cookie}`;
+        const parts = value.split(`; ${name}=`);
+        if (parts.length === 2) return parts.pop().split(';').shift();
+    }
+  
+  // 토큰 갱신
+    const refreshToken = async () => {
+        try {
+        const refreshResponse = await axios.post('http://localhost:8081/reissue', {
+            userCode: loggedInUser.userCode
+        }, {
+            withCredentials: true
+        });
+    
+        if (refreshResponse.status === 200) {
+            console.log('토큰 갱신 성공');
+            // 쿠키에서 새 액세스 토큰을 확인
+            const newAccessToken = getCookie('access');
+
+            if (newAccessToken) {
+            console.log('새 액세스 토큰이 설정되었습니다');
+            } else {
+            console.log('새 액세스 토큰을 찾을 수 없습니다');
+            }
+
+            window.location.reload();
+
+        } else {
+            console.log('토큰 갱신 실패');
+            console.log('응답 정보:', refreshResponse);
+        }
+        } catch (error) {
+        console.error('토큰 갱신 중 오류 발생:', error);
+        }
+    };
+
     const handleProfilePicChange = async (event) => {
         const file = event.target.files[0];
         if (file) {
@@ -110,8 +148,8 @@ const MyPage = ({user}) => {
                     ...prevUser,
                     profilePic: downloadURL
                 }));
-                window.location.reload();
-                
+                await refreshToken();
+
             } catch (error) {
                 console.error('프로필사진 변경 실패:', error);
                 if (error.response) {


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[REFACTOR][EDITPROFILE] 

### 💡 작업동기
- 문제점
  프로필 사진 변경 시 헤더에 있는 프로필 사진이 변경되지 않음.
  이유는 엑세스 토큰안에 프로필사진 정보를 담았기 때문,
  엑세스 토큰을 재발급 받지 않는 이상 프로필 사진 정보는 프로필 사진 초기 값을 유지함.

- 해결방안
  프로필 사진 변경을 하면 토큰 재발급을 통해 프로필 사진의 정보도 갱신해줌.

### 🔑 주요 변경사항
- Mypage.js 프로필 업데이트 구간에 토큰 재발급 함수 호출
- ExpiredToken.js에 디코딩 형식 변경 
  -  const tokenPayload = jwtDecode(accessToken);
### 🏞 스크린샷
- 토큰 갱신 성공 하면 reload
![image](https://github.com/user-attachments/assets/3f8e5481-849b-4823-987d-d1a9872c7181)

- 프로필 수정이 응답 되면 토큰 함수 호출
![image](https://github.com/user-attachments/assets/102adade-7685-4b0e-963d-1fe03361a999)

- 확인 이상 무
![image](https://github.com/user-attachments/assets/78274fab-25ac-45d0-bfb7-ec57936edc93)


### 관련 이슈
- close #134 

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
