### PR TITLE
[FEATURE][CULTUREINFO][BUGFIX] - 공연/전시 정보 카테고리 클릭 에러 및 얼리버드 카테고리 관련 에러 수정

### DIFF
--- a/src/components/cultureInfo/CardType.js
+++ b/src/components/cultureInfo/CardType.js
@@ -3,16 +3,6 @@ import styles from '../../pages/cultureInfo/CultureInfo.module.css';
 import LoadingSpinner from '../commons/Loading';
 
 export default function CardType({cultureList, detailDataList, earlyCheck}){
-  // console.log('Culture List:', cultureList);
-  // console.log('Detail Data List:', detailDataList);
-  // console.log('earlyCheck:', earlyCheck);
-
-  // 데이터가 로딩 중일 때 처리
-  // if (!cultureList || !cultureList.perforList || !detailDataList) {
-  //   return <LoadingSpinner />;
-  // }
-
-  // console.log("detailList from CardType.js : "+ JSON.stringify(detailDataList));
 
   const today = new Date();
   return(
@@ -49,7 +39,6 @@ export default function CardType({cultureList, detailDataList, earlyCheck}){
 
             // 얼리버드 공연/전시 가격 1000단위 ,
             const convertPriceFormat = (dPrice) => {
-              console.log("dPrice : ",dPrice);
               if (!dPrice && dPrice !== 0) { // dPrice가 유효하지 않은 경우를 처리
                 return "가격 정보 업데이트중"; // 기본 값 반환
               }
@@ -66,13 +55,7 @@ export default function CardType({cultureList, detailDataList, earlyCheck}){
 
             // detailData가 존재하고 price 속성이 있을 때 가격 표시
             const price = earlyCheck || item?.regularPrice ? convertPriceFormat(item?.discountPrice || item?.price) : detailData && detailData.price ? detailData.price : "가격 정보 없음";
-            // const detailData = detailDataList[item.seq]; // seq(공연/전시 코드)에 따른 상세 정보
-            // console.log("price from cardtype : " + JSON.stringify(detailData));
             const discountRate = earlyCheck || item?.regularPrice ? parseInt((item?.discountPrice || item?.price)/ item?.regularPrice * 100) : null;
-            // console.log("discount Rate : ", item);
-            // console.log("discount Rate : " + typeof item?.discountPrice);
-            // console.log("discount Rate : " + item?.regularPrice);
-            // console.log("discount Rate : " + (item.discountPrice / item.regularPrice * 100));
             
             return(
               <li key={index}>
@@ -92,8 +75,7 @@ export default function CardType({cultureList, detailDataList, earlyCheck}){
                 </Link>
               </li>
             );          
-          }) : <div>로딩 중입니다.</div>}
+          }) : <LoadingSpinner/>}
       </>
   );
 }
-{/* <LoadingSpinner/> */}

--- a/src/components/cultureInfo/TableType.js
+++ b/src/components/cultureInfo/TableType.js
@@ -96,12 +96,17 @@ export default function TableType({cultureList, detailDataList, earlyCheck}){
 
             // detailData가 존재하고 price 속성이 있을 때 가격 표시
             const price = earlyCheck || item?.regularPrice ? convertPriceFormat(item?.discountPrice || item?.price) : detailData && detailData.price ? detailData.price : "가격 정보 없음";
+
+            console.log("장르 카테고리 : "+ earlyCheck ? categoryString(earlyCheck?.interestCode) : category(item?.realmName));
+            console.log("장르 카테고리 : "+ categoryString(earlyCheck?.interestCode));
+            console.log("장르 카테고리 : "+ earlyCheck?.interestCode);
             
             return(            
-                <tr onClick={() => navigate( earlyCheck ? `/cultureinfo/detail/${item?.earlyBirdCode}` : `/cultureinfo/detail/${item?.seq}`)} key={index}  state={{ earlyCheck: true }}>
-                  <td>{earlyCheck ? categoryString(earlyCheck?.interestCode) : category(item?.realmName)}</td>
+                <tr onClick={() => navigate(
+                  earlyCheck ? `/cultureinfo/detail/${item?.earlyBirdCode}` : `/cultureinfo/detail/${item?.seq}`,{ state: { earlyCheck: earlyCheck || item?.regularPrice ? true : false }})} key={index}>
+                  <td>{earlyCheck ? categoryString(item?.interestCode) : category(item?.realmName)}</td>
                   <td>{title}</td>
-                  <td>{price}</td>
+                  <td>{price}{earlyCheck || item?.regularPrice ? `원` : null}</td>
                   <td>{earlyCheck || item?.regularPrice ? <p className={styles.culture_date}>{formatDate(item?.saleStartDate || item?.startDate)} ~ {formatDate(item?.saleEndDate || item?.endDate)}</p> : <p className={styles.culture_date}>{convertDateFormat(item?.startDate)} ~ {convertDateFormat(item?.endDate)}</p>}</td>
                 </tr>
               

--- a/src/components/main/TopBanner.js
+++ b/src/components/main/TopBanner.js
@@ -3,37 +3,62 @@ import '../../styles/slick.css';
 import mainStyle from '../../pages/main/Main.module.css';
 import Slider from "react-slick";
 import { Link } from 'react-router-dom';
+import { useEffect, useRef, useState } from 'react';
 
-export default function TopBanner({pickList}) {
+export default function TopBanner({ pickList }) {
   // if (cultureList) {
   //   console.log("cultureList from TopBanner : " + cultureList.cultureList?.perforList);
   //   console.log("cultureList from TopBanner : " + cultureList.cultureList?.perforList[0].thumbnail);
   // }
+
   const settings = {
     className: "center",
     centerMode: true,
-    infinite: true,
+    infinite: pickList.perforList?.length > 2,
     centerPadding: "60px",
-    slidesToShow: 3,
+    slidesToShow: Math.min(pickList.perforList?.length || 1, 3),
+    // slidesToShow: pickList.perforList?.length >= 3 ? 3 : pickList.perforList?.length,
     speed: 1000,
-    dots: true,
-    autoplay: true,
+    dots: pickList.perforList?.length > 1,
+    autoplay: pickList.perforList?.length > 1,
     autoplaySpeed: 3000,
     pauseOnHover: true,
     arrows: false,
   };
+
   return (
     <div className={`slider-container ${mainStyle.top_banner_box}`}>
-      <Slider {...settings}>        
-        {pickList && pickList.perforList ? [...Array(parseInt(10))].map((n, index) => {
-          return(
-            <div className={mainStyle.centerList} key={index}>
-              <Link to={`/cultureinfo/detail/${pickList.perforList[index]?.seq}`}>  
-                <img src={pickList.perforList[index]?.thumbnail} alt={`${pickList.perforList[index]?.title} thumbnail`}/>            
-              </Link>
-            </div>
-          );          
-        }) : <div>Loading중입니다.</div>}
+      <Slider {...settings}>
+        {pickList && pickList.perforList ? (
+          pickList.perforList.length > 10
+            ? pickList.perforList.slice(0, 10).map((item, index) => (
+              <div className={mainStyle.centerList} key={index}>
+                <Link to={`/cultureinfo/detail/${item.seq}`} state={item.regularPrice ? { earlyCheck: true } : { earlyCheck: false }}>
+                  <img src={item.thumbnail} alt={`${item.title} thumbnail`} />
+                </Link>
+              </div>
+            ))
+            : pickList.perforList.length > 1
+              ? [...Array(4)].map((_, index) => {
+                const item = pickList.perforList[index % pickList.perforList.length];
+                return (
+                  <div className={mainStyle.centerList} key={index}>
+                    <Link to={`/cultureinfo/detail/${item.seq}`} state={item.regularPrice ? { earlyCheck: true } : { earlyCheck: false }}>
+                      <img src={item.thumbnail} alt={`${item.title} thumbnail`} />
+                    </Link>
+                  </div>
+                );
+              })
+              : pickList.perforList.map((item, index) => (
+                <div className={mainStyle.centerList} key={index}>
+                  <Link to={`/cultureinfo/detail/${item.seq}`} state={item.regularPrice ? { earlyCheck: true } : { earlyCheck: false }}>
+                    <img src={item.thumbnail} alt={`${item.title} thumbnail`} />
+                  </Link>
+                </div>
+              ))
+        ) : (
+          <div>Loading...</div>
+        )}
       </Slider>
     </div>
   );

--- a/src/pages/cultureInfo/CultureInfo.js
+++ b/src/pages/cultureInfo/CultureInfo.js
@@ -82,7 +82,7 @@ export default function CultureInfo(props) {
 
         const addedCultureListObj = cultureListObj.perforList.concat(filteredEb);
         console.log("filteredEarlyBird : ",filteredEarlyBird);
-        console.log("concat : ",addedCultureListObj);
+        console.log("concat from CultureInfo page : ",addedCultureListObj);
 
         const totalCount = addedCultureListObj.length; // totalCount 값 가져오기
         console.log("totalCount from public api: ", totalCount);    
@@ -97,7 +97,8 @@ export default function CultureInfo(props) {
             realmCounts["전시"]++;
           } else if(titName.match("뮤지컬") || realmName.match("기타") || realmName.match("뮤지컬")){
             realmCounts["뮤지컬"]++;
-          } else if(realmName.match("음악") || titName.match("콘서트") || realmName === "연극"|| titName.match("영화") || realmName.match("공연") || titName.match("주회") || titName.match("공연")){
+          } else if(["음악", "무용", "연극", "국악"].includes(item.realmName) && !item.title.match(/페스티벌|축제/)){
+            //realmName.match("음악") || titName.match("콘서트") || realmName === "연극"|| titName.match("영화") || realmName.match("공연") || titName.match("주회") || titName.match("공연")
             realmCounts["공연"]++;
           } else if(titName.match("행사") || titName.match("축제") || titName.match("페스티벌") || realmName.match("축제") || titName.includes("페스티벌") || titName.includes("축제")){
             realmCounts["축제"]++;
@@ -115,7 +116,7 @@ export default function CultureInfo(props) {
         
         // setCultureList(JSON.parse(props.cultureList)); // JSON형태로 cultureList 저장 
         setCultureList({...cultureListObj , perforList : addedCultureListObj}); // JSON형태로 cultureList 저장 
-        setFilteredList({...cultureListObj , perforList : addedCultureListObj.sort((a,b) => {return Number(a.endDate) - Number(b.endDate)})})
+        setFilteredList({...cultureListObj , perforList : addedCultureListObj.sort((a,b) => {return Number(a.endDate) - Number(b.endDate)})}) // 필터링 초기화 적용된 리스트
         setHotList(JSON.parse(props.cultureList));          
         
         //공연/전시 대분류 카테고리 버튼
@@ -142,13 +143,15 @@ export default function CultureInfo(props) {
             // 해당 카테고리에 맞는 cultureList 필터링
             let filteredList = [];
             if (genre === "all") { // 전체
-              filteredList = cultureListObj.perforList.sort((a, b) => Number(a.endDate) - Number(b.endDate)); // 전체보기일 경우 전체 리스트 반환
+              filteredList = addedCultureListObj.sort((a, b) => Number(a.endDate) - Number(b.endDate)); // 전체보기일 경우 전체 리스트 반환
               setIsEarly(false);
             } else if(genre === "미술"){ // 전시
               filteredList = addedCultureListObj.filter(item => item.realmName === genre || item.title.match("전시") || item.realmName.match("전시")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
               setIsEarly(false);
             } else if(genre === "음악"){ // 공연
-              filteredList = addedCultureListObj.filter(item => item.realmName === genre || item.realmName === "연극" || item.title.match("음악") || item.title.match("영화") || item.realmName.match("공연") || item.title.match("콘서트") || item.title.match("연주") || item.title.match("주회")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
+              filteredList = addedCultureListObj.filter(item => ["음악", "무용", "연극", "국악"].includes(item.realmName) && !item.title.match(/페스티벌|축제/));
+              //item => item.realmName === genre || item.realmName === "연극" || item.title.match("음악") || item.title.match("영화") || item.realmName.match("공연") || item.title.match("콘서트") || item.title.match("연주") || item.title.match("주회")).sort((a, b) => Number(a.endDate) - Number(b.endDate)
+              //["음악", "무용", "연극", "국악"].includes(item.realmName) && !item.title.match(/페스티벌|축제/)
               setIsEarly(false);
             } else if(genre === "뮤지컬"){ // 뮤지컬
               filteredList = addedCultureListObj.filter(item => item.title.match("뮤지컬") || item.realmName.match("기타") || item.realmName.match("뮤지컬")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
@@ -165,7 +168,7 @@ export default function CultureInfo(props) {
             }
 
             // 필터링된 결과를 cultureList 상태에 업데이트
-            setCultureList({ ...cultureListObj, perforList: filteredList });
+            setCultureList({ ...cultureListObj, perforList: filteredList }); // 장르 카테고리 선택된 상태의 리스트로 culturelist 업데이트
             setFilteredList({ ...cultureListObj, perforList: filteredList });
             setCurrentPage(1); // 페이지를 1로 초기화
           });
@@ -188,10 +191,6 @@ export default function CultureInfo(props) {
     },[earlyCount, publicCount]
   );
   
-  // useEffect(() => {
-  //   console.log("cultureList : ", cultureList);
-  // }, [cultureList]);
-  
   
   useEffect(
     () => {
@@ -213,50 +212,54 @@ export default function CultureInfo(props) {
       // const cultureListObj = JSON.parse(props.cultureList);
       console.log("현재 클릭한 필터 : " + e.currentTarget.innerText);
       console.log("현재 선택한 카테고리 : " + category);
-
-      let filteredListCategory = [];
       let filteredListAfterSubFiltered = [];
 
-      if (category === "all") { // 전체
-        filteredListCategory = cultureListObj.perforList.sort((a, b) => Number(a.endDate) - Number(b.endDate)); // 전체보기일 경우 전체 리스트 반환
-      } else if(category === "미술"){ // 전시
-        filteredListCategory = cultureListObj.perforList.filter(item => item.realmName === category || item.title.match("전시") || item.realmName.match("전시")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
-      } else if(category === "음악"){ // 공연
-        filteredListCategory = cultureListObj.perforList.filter(item => item.realmName === category || item.realmName === "연극" || item.title.match("음악") || item.title.match("영화") || item.realmName.match("공연")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
-      } else if(category === "뮤지컬"){ // 뮤지컬
-        filteredListCategory = cultureListObj.perforList.filter(item => item.title.match("뮤지") || item.title.match("뮤지컬") || item.realmName.match("기타") || item.realmName.match("뮤지컬")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
-      } else if(category === "축제"){ // 행사 / 축제
-        filteredListCategory = cultureListObj.perforList.filter(item => item.title.match("축제") || item.title.match("페스티벌") || item.realmName.match("축제")).sort((a, b) => Number(a.endDate) - Number(b.endDate));
-      } else if(category === "얼리버드"){ // 얼리버드
-        filteredListCategory = cultureListObj.sort((a,b) => {return Number(a.saleEndDate) - Number(b.saleEndDate)});
-      }
-
       if (e.currentTarget.innerText === "마감임박순") {
-        filteredListAfterSubFiltered = areaFilter === "전체 지역" ? filteredListCategory.sort((a, b) => Number(a.endDate) - Number(b.endDate)) : filteredListCategory.filter(item => item.area.match(areaFilter)).sort((a, b) => Number(a.endDate) - Number(b.endDate));
+        console.log("filteredList from 마감임박순 : ", filteredList.perforList);
+        filteredListAfterSubFiltered = areaFilter === "전체 지역" ? filteredList.perforList.sort((a, b) => Number(a.endDate) - Number(b.endDate)) : filteredList.perforList.filter(item => item.area.match(areaFilter)).sort((a, b) => Number(a.endDate) - Number(b.endDate));
         setSubFilter(e.currentTarget.innerText);
       } else if (e.currentTarget.innerText === "최신등록순") {
-        filteredListAfterSubFiltered = areaFilter === "전체 지역" ? filteredListCategory.sort((a, b) => Number(b.startDate) - Number(a.startDate)) : filteredListCategory.filter(item => item.area.match(areaFilter)).sort((a, b) => Number(b.startDate) - Number(a.startDate));
+        console.log("filteredList from 최신등록순: ", filteredList.perforList);
+        filteredListAfterSubFiltered = areaFilter === "전체 지역" ? filteredList.perforList.sort((a, b) => Number(b.startDate || b.saleStartDate) - Number(a.startDate || a.saleStartDate)) : filteredList.perforList.filter(item => (item.area || item.region) && typeof (item.area || item.region) === 'string' && (item.area || item.region).includes(e.currentTarget.innerText));
+        // filteredListAfterSubFiltered = areaFilter === "전체 지역" ? filteredList.perforList.sort((a, b) => Number(b.startDate) - Number(a.startDate)) : filteredList.perforList.filter(item => item.area.match(areaFilter)).sort((a, b) => Number(b.startDate) - Number(a.startDate));
         setSubFilter(e.currentTarget.innerText);
-      } else if (e.currentTarget.innerText === "가격순") {
-        filteredListAfterSubFiltered = filteredListCategory.sort((a, b) => Number(b.startDate) - Number(a.startDate));
-        setSubFilter(e.currentTarget.innerText);
-      } else if (e.currentTarget.innerText === "허니팟 많은순") {
-        setSubFilter(e.currentTarget.innerText);
-      } else if (e.currentTarget.innerText === "인기순") {
-        setSubFilter(e.currentTarget.innerText);
-      }else if (e.currentTarget.innerText === "전체 지역") {
+      }
+
+      setFilteredList({ ...cultureListObj, perforList: filteredListAfterSubFiltered });
+      // setCultureList({ ...cultureListObj, perforList: filteredListAfterSubFiltered });
+      setCurrentPage(1);
+    };
+
+    const subFilterRegionItemHandler = (e) => {
+      e.currentTarget.closest("ul").classList.remove(`.${styles.active}`);
+      const cultureListObj = cultureList;
+      // const cultureListObj = JSON.parse(props.cultureList);
+      console.log("현재 클릭한 지역 필터 : " + e.currentTarget.innerText);
+      console.log("현재 선택한 장르 카테고리 : " + category);
+      let filteredListAfterSubFiltered = [];
+
+      if (e.currentTarget.innerText === "전체 지역") {
         setAreaFilter("전체 지역");
-        filteredListAfterSubFiltered = filteredListCategory;
+        console.log("전체 지역 클릭시 filteredList : ", filteredList.perforList);
+        console.log("전체 지역 클릭시 cultureList : ", cultureList.perforList);
+        filteredListAfterSubFiltered = cultureList.perforList;
       } else {
         console.log("areaFilter : " + areaFilter);
         setAreaFilter(e.currentTarget.innerText);
         console.log("after areaFilter : " + areaFilter);
-        const areaFiltered = filteredListCategory.filter(item => item.area.match(e.currentTarget.innerText));
+        // console.log("filteredList in other area selected :",  filteredList);
+        console.log("타 지역 클릭시 filteredList : ", filteredList.perforList);
+        console.log("타 지역 클릭시 cultureList : ", cultureList.perforList);        
+        // const areaFiltered = filteredListCategory.filter(item => item.area.match(e.currentTarget.innerText));
+        const areaFiltered =  cultureList.perforList.filter(item => (item.area || item.region) && typeof (item.area || item.region) === 'string' && (item.area || item.region).includes(e.currentTarget.innerText));
+        console.log('areaFiltered after selected : ', areaFiltered);
         filteredListAfterSubFiltered = subFilter === "마감임박순" ? areaFiltered.sort((a, b) => Number(a.endDate) - Number(b.endDate)) : areaFiltered.sort((a, b) => Number(b.startDate) - Number(a.startDate));
+        console.log('filteredListAfterSubFiltered after sorted : ', filteredListAfterSubFiltered);
       }
 
       setFilteredList({ ...cultureListObj, perforList: filteredListAfterSubFiltered });
-      setCultureList({ ...cultureListObj, perforList: filteredListAfterSubFiltered });
+      // setFilteredList({ ...cultureListObj, perforList: filteredList.perforList });
+      // setCultureList({ ...cultureListObj, perforList: filteredListAfterSubFiltered });
       setCurrentPage(1);
     };
 
@@ -292,15 +295,32 @@ export default function CultureInfo(props) {
     console.log("검색할 때 참조하는 filtered리스트 : ",filteredList?.perforList);
     console.log("검색할 때 참조하는 culture리스트 : ",cultureList?.perforList);
     // console.log("현재 filteredList : ", filteredList?.perforList);
-    console.log("검색한 결과 : ", cultureList?.perforList.filter(item => (item.title.toLowerCase()).includes(searchValue.toLowerCase())))
-    const searchedListNow = cultureList?.perforList.filter(item => (item.title.toLowerCase()).match(searchValue.toLowerCase()));
+    console.log("검색한 결과 : ", filteredList?.perforList.filter(item => {
+      const title = item.title || '';
+      const ebTitle = item.ebTitle || '';
+      return title.toLowerCase().includes(searchValue.toLowerCase()) || 
+             ebTitle.toLowerCase().includes(searchValue.toLowerCase());
+    }))
+    // const searchedListNow = filteredList?.perforList.filter(item => (item.title.toLowerCase() || item.ebTitle).match(searchValue.toLowerCase()));
+    const searchedListNow = filteredList?.perforList.filter(item => {
+      const title = item.title || '';
+      const ebTitle = item.ebTitle || '';
+      return title.toLowerCase().includes(searchValue.toLowerCase()) || 
+             ebTitle.toLowerCase().includes(searchValue.toLowerCase());
+    });
     // setSearchedList(searchedListNow);
-    setFilteredList({...cultureList, perforList : searchedListNow});
-    if(searchedListNow.length === 0){ // 검색어가 없는 경우
-      setNullText(`[${searchValue}] 검색 결과가 존재하지 않습니다.`);
-    }else{
-      setNullText("현재 해당 정보가 존재하지 않습니다.");
-    }
+    if(searchValue === '' || null){ // 검색어를 입력하지 않은 경우
+      setFilteredList({...cultureList, perforList : cultureList.perforList}); // 카테고리 선택한 리스트로 초기화
+      setSubFilter("마감임박순");
+      setAreaFilter("전체 지역");
+    }else{ // 검색어를 입력한 경우
+      setFilteredList({...cultureList, perforList : searchedListNow});
+      if(searchedListNow.length === 0){ // 검색어가 없는 경우      
+        setNullText(`[${searchValue}] 검색 결과가 존재하지 않습니다.`);
+      }else{
+        setNullText(`현재 해당 정보가 존재하지 않습니다.`);
+      }
+    }    
     
     setSearchValue('') // 검색 후 검색 결과 초기화 
   }
@@ -500,31 +520,31 @@ export default function CultureInfo(props) {
                     <li data-filter="deadline" onClick={(e) => subFilterItemHandler(e)}>마감임박순</li>
                     <li data-filter="lately" onClick={(e) => subFilterItemHandler(e)}>최신등록순</li>
                     {/* <li data-filter="low">가격낮은순</li> */}
-                    <li data-filter="honeyPot" onClick={(e) => subFilterItemHandler(e)}>허니팟 많은순</li>
+                    {/* <li data-filter="honeyPot" onClick={(e) => subFilterItemHandler(e)}>허니팟 많은순</li> */}
                     {/* <li data-filter="hot">인기순</li> */}
                   </ul>
                 </li>
                 <li className={`${styles.right_filter} ${styles.region_filter}`} onClick={(e) => subFilterHandler(e)}>
                   <span className={`${styles.selected_filter} ${styles.right} ${styles.flex_between}`}><span className={`${styles.selected_option} ${styles.right_detail_selected}`}>{areaFilter}</span><img src={`${process.env.PUBLIC_URL}/images/commons/icon_arrow_bottom_main_color.png`} alt="arrow direction bottom icon" className={styles.filter_arrow_icon} /></span>
                   <ul>
-                    <li onClick={(e) => subFilterItemHandler(e)}>전체 지역</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>서울</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>인천</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>부산</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>경기</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>충북</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>충남</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>경남</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>경북</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>대구</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>대전</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>광주</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>세종</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>울산</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>강원</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>전남</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>전북</li>
-                    <li onClick={(e) => subFilterItemHandler(e)}>제주</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>전체 지역</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>서울</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>인천</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>부산</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>경기</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>충북</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>충남</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>경남</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>경북</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>대구</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>대전</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>광주</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>세종</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>울산</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>강원</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>전남</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>전북</li>
+                    <li onClick={(e) => subFilterRegionItemHandler(e)}>제주</li>
                   </ul>
                 </li>
               </ul>
@@ -554,7 +574,7 @@ export default function CultureInfo(props) {
               <img src={`${process.env.PUBLIC_URL}/images/commons/logo.png`} alt="logo" />
               {/* <p>현재 해당 정보가 존재하지 않습니다.</p> */}
               <p>{nullText}</p>
-              <p>빠른 정보 업데이트로 찾아뵙겠습니다.</p>
+              <p>검색어를 다시 입력해주세요.</p>
             </div>
             :
               /* 카드 형식 */

--- a/src/pages/main/Main.module.css
+++ b/src/pages/main/Main.module.css
@@ -34,8 +34,8 @@
 .top_banner_box {padding-top: 40px;}
 /* Center slick slide */
 .centerList {padding: 10px;}
-.centerList > a {position: relative; display: block; height: 500px; margin: 10px; padding: 2%; transition: all .3s ease;}
-.centerList > a > img {display: block; width: 100%; height: 100%; object-fit: cover; object-position: top; border-radius:20px;}
+.centerList > a {position: relative; display: flex; justify-content: center; height: 500px; margin: 10px; padding: 2%; transition: all .3s ease;}
+.centerList > a > img {display: block; width: 100%; max-width:360px; height: 100%; object-fit: cover; object-position: top; border-radius:20px;}
 
 /* 전시/공연 정보 */
 .hot_prf_sec {padding-top: 80px;}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[FEATURE][CULTUREINFO][BUGFIX]

### 💡 작업동기
 - 공연/전시 정보 카테고리 클릭 에러 및 얼리버드 카테고리 관련 에러 수정 작업입니다.

### 🔑 주요 변경사항
-  공연/전시 정보 카테고리 클릭이 안되는 에러 해결
- 카테고리 선택 후, 마감임박순/최신등록순 카테고리 선택 다음 지역 선택시 필터링되도록 작업
- 얼리버드 카테고리 클릭 후, 보기방식 테이블로 변경 후 클릭하면 상세 페이지 정상 출력

### 🏞 스크린샷
### [공연]카테고리 선택 후, [서울]지역 카테고리 필터
![image](https://github.com/user-attachments/assets/1c56828a-dc0d-44e5-866a-11f9538e342e)

### 위 필터된 상태에서 [서울]검색어 입력시,
![image](https://github.com/user-attachments/assets/5f006998-fccb-464a-90a0-2a821f2d5227)

### 얼리버드 카테고리 선택 후, 테이블 형식 보기 선택
![image](https://github.com/user-attachments/assets/8439d685-9f44-4e77-a2b0-ee2b6d46a3a5)

### 상세 페이지 정상 연결
![image](https://github.com/user-attachments/assets/085dcdb4-2c65-4dfd-b7cb-f85c92581545)



### 관련 이슈
- 관련 이슈를 입력해주세요.

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
