### PR TITLE
[FEATURE][MYPAGE][HONEYPOT][REFACTOR] 유저평가 로직 변경, 허니팟 리스트 뷰 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -107,7 +107,7 @@ export default function App() {
     }
   }, [decodedToken]);
 
-  console.log("앱JS 유저", loggedInUser);
+  // console.log("앱JS 유저", loggedInUser);
 
   return (
     <>

--- a/src/components/honeypot/HoneypotList.css
+++ b/src/components/honeypot/HoneypotList.css
@@ -184,3 +184,23 @@
     opacity: 0.3;
     cursor: default;
 }
+
+.honeypot-null-box {
+    width: 100%;
+    min-height: 400px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.honeypot-null-box img {
+    margin-bottom: 20px;
+    width: 200px;
+    height: 200px;
+}
+
+.honeypot-null-txt {
+    font-size: 20px;
+    margin-bottom: 10px;
+}

--- a/src/components/honeypot/HoneypotList.js
+++ b/src/components/honeypot/HoneypotList.js
@@ -1,12 +1,9 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import "./HoneypotList.css";
-import { useState, useEffect } from 'react';
-import ApplicationApi from "../../apis/honeypot/ApplicationApi";
 
 function HoneypotList({ currentPage, setCurrentPage, pageGroup, setPageGroup, honeypots, user }) {
   
   const honeypotsPerPage = 10;
-  // console.log('이건뭐지', honeypots)
 
   // 비활성화 필터링
   const activeHoneypots = honeypots.filter(honeypot => honeypot.visibilityStatus === "활성화")
@@ -22,7 +19,6 @@ function HoneypotList({ currentPage, setCurrentPage, pageGroup, setPageGroup, ho
     indexOfLastHoneypot
   );
 
-
   // 총 페이지 수 계산
   const totalPages = Math.ceil(finishedHoney.length / honeypotsPerPage);
   const maxPageButtons = 5;
@@ -33,13 +29,13 @@ function HoneypotList({ currentPage, setCurrentPage, pageGroup, setPageGroup, ho
 
   const handleCurrentPageGroupFirstPage = () => {
     const currentPageGroupStartPage = pageGroup * maxPageButtons + 1;
-    setCurrentPage(currentPageGroupStartPage); // 현재 페이지 그룹의 첫 번째 페이지로 이동
+    setCurrentPage(currentPageGroupStartPage);
   };
 
   const handleCurrentPageGroupLastPage = () => {
     const currentPageGroupStartPage = pageGroup * maxPageButtons + 1;
     const currentPageGroupEndPage = Math.min(currentPageGroupStartPage + maxPageButtons - 1, totalPages);
-    setCurrentPage(currentPageGroupEndPage); // 현재 페이지 그룹의 마지막 페이지로 이동
+    setCurrentPage(currentPageGroupEndPage);
   };
 
   const handlePrevPage = () => {
@@ -50,7 +46,7 @@ function HoneypotList({ currentPage, setCurrentPage, pageGroup, setPageGroup, ho
       }
     } else if (pageGroup > 0) {
       setPageGroup(pageGroup - 1);
-      setCurrentPage(endPage - maxPageButtons + 1); // 이전 페이지 그룹의 마지막 페이지로 이동
+      setCurrentPage(endPage - maxPageButtons + 1);
     }
   };
 
@@ -62,66 +58,74 @@ function HoneypotList({ currentPage, setCurrentPage, pageGroup, setPageGroup, ho
       }
     } else if (pageGroup < totalGroups - 1) {
       setPageGroup(pageGroup + 1);
-      setCurrentPage(startPage + 1); // 다음 페이지 그룹의 첫 번째 페이지로 이동
+      setCurrentPage(startPage + 1);
     }
   };
 
   const navigate = useNavigate();
 
-  console.log('커런트허니팟', currentHoneypots);
-
   return (
     <div className="honeypot-list-container">
-      {currentHoneypots.map((honeypot, index) => (
-        <div key={index} className="one-honeypot-index"
-         onClick={ () => {navigate(`/honeypot/detail/${honeypot.honeypotCode}`)}}>
-          <div className="honeypot-index-poster">
-            <img src={honeypot.poster} alt="포스터이미지" />
-            <hr className="honeypot-dashed" />
-          </div>
-          <div className="honeypot-index-info">
-            <div className="top-info">
-              <div className="region-info">{honeypot.region}</div>
-              <div className="category-info">{honeypot.interestName}</div>
-              <div className="honeypot-status">{honeypot.closureStatus}</div>
-            </div>
-            <p className="honeypot-title">{honeypot.honeypotTitle}</p>
-            <div className="honeypot-schedule">
-              <div>일정</div>
-              <p className="honeypot-date">{honeypot.eventDate}</p>
-              <p className="total-member">
-                참여인원 {honeypot.approvedCount + 1} / {honeypot.totalMember}
-              </p>
-            </div>
-            <p className="end-date">{honeypot.endDate} 까지 모집해요</p>
-          </div>
+      {finishedHoney.length === 0 ? (
+        <div className="honeypot-null-box">
+          <img src={`${process.env.PUBLIC_URL}/images/commons/logo.png`} alt="null page" />
+          <p className="honeypot-null-txt">아직 등록된 허니팟이 없어요</p>
+          <p className="honeypot-null-txt">지금 바로 허니팟 호스트가 되어 주세요</p>
         </div>
-      ))}
-      <div className="pagination-container">
-        <div className="pagination">
-          <button className='first-btn' onClick={handleCurrentPageGroupFirstPage} disabled={currentPage === 1}>
-            &lt;&lt;
-          </button>
-          <button className='prev-btn' onClick={handlePrevPage} disabled={currentPage === 1}>
-            &lt;
-          </button>
-          {Array.from({ length: endPage - startPage + 1 }, (_, index) => (
-            <button
-              key={index}
-              className={`page-button ${startPage + index === currentPage ? 'active' : ''}`}
-              onClick={() => setCurrentPage(startPage + index)}
-            >
-              {startPage + index}
-            </button>
+      ) : (
+        <>
+          {currentHoneypots.map((honeypot, index) => (
+            <div key={index} className="one-honeypot-index"
+             onClick={ () => {navigate(`/honeypot/detail/${honeypot.honeypotCode}`)}}>
+              <div className="honeypot-index-poster">
+                <img src={honeypot.poster} alt="포스터이미지" />
+                <hr className="honeypot-dashed" />
+              </div>
+              <div className="honeypot-index-info">
+                <div className="top-info">
+                  <div className="region-info">{honeypot.region}</div>
+                  <div className="category-info">{honeypot.interestName}</div>
+                  <div className="honeypot-status">{honeypot.closureStatus}</div>
+                </div>
+                <p className="honeypot-title">{honeypot.honeypotTitle}</p>
+                <div className="honeypot-schedule">
+                  <div>일정</div>
+                  <p className="honeypot-date">{honeypot.eventDate}</p>
+                  <p className="total-member">
+                    참여인원 {honeypot.approvedCount + 1} / {honeypot.totalMember}
+                  </p>
+                </div>
+                <p className="end-date">{honeypot.endDate} 까지 모집해요</p>
+              </div>
+            </div>
           ))}
-          <button className='next-btn' onClick={handleNextPage} disabled={currentPage === totalPages}>
-            &gt;
-          </button>
-          <button className='last-btn' onClick={handleCurrentPageGroupLastPage} disabled={currentPage === totalPages}>
-            &gt;&gt;
-          </button>
-        </div>
-      </div>
+          <div className="pagination-container">
+            <div className="pagination">
+              <button className='first-btn' onClick={handleCurrentPageGroupFirstPage} disabled={currentPage === 1}>
+                &lt;&lt;
+              </button>
+              <button className='prev-btn' onClick={handlePrevPage} disabled={currentPage === 1}>
+                &lt;
+              </button>
+              {Array.from({ length: endPage - startPage + 1 }, (_, index) => (
+                <button
+                  key={index}
+                  className={`page-button ${startPage + index === currentPage ? 'active' : ''}`}
+                  onClick={() => setCurrentPage(startPage + index)}
+                >
+                  {startPage + index}
+                </button>
+              ))}
+              <button className='next-btn' onClick={handleNextPage} disabled={currentPage === totalPages}>
+                &gt;
+              </button>
+              <button className='last-btn' onClick={handleCurrentPageGroupLastPage} disabled={currentPage === totalPages}>
+                &gt;&gt;
+              </button>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/pages/main/Main.js
+++ b/src/pages/main/Main.js
@@ -22,7 +22,7 @@ export default function Main(props) {
   const [filteredEarlyBird, setFilteredEarlyBird] = useState([]);
   const navigate = useNavigate();
 
-  console.log("메인페이지유저정보", props.user);
+  // console.log("메인페이지유저정보", props.user);
 
 
   //app.js에서 전달받은 api정보 state 저장


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[FEATURE][MYPAGE][HONEYPOT][REFACTOR]

### 💡 작업동기
- 마이페이지 - 백엔드에서만 중복확인, 프론트에도 추가
- 허니팟페이지 - 리스트에서 빈 카테고리 시 아무것도 보이지 않음

### 🔑 주요 변경사항
- 마이페이지 - 유저평가 관련 유효성 체크 변경(중복 확인 여부 호출)
                        중복여부 체크하는 API 호출하여 비교 후 비활성화
- 허니팟페이지 - 리스트에서 빈 카테고리 시 VIEW 추가

### 🏞 스크린샷
- 마이페이지
   ![image](https://github.com/user-attachments/assets/4d59b277-e156-4b48-8b01-af55d6bfa5fd)


- 허니팟 페이지
  ![image](https://github.com/user-attachments/assets/5ef2d70e-7b6b-404a-8e66-12a693b6708a)


### 관련 이슈
- #155 

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
