### PR TITLE
[FEATURE][HONEYPOT][EARLYBIRD]허니팟 디테일 페이지 얼리버드 정보 추가

### DIFF
--- a/src/apis/CultureApi.js
+++ b/src/apis/CultureApi.js
@@ -223,7 +223,7 @@ export default function CultureApi({ setData }) {
      MsgBody: '',
      cPage: '1',
      rows: '150', // 1페이지에 불러올 데이터 갯수
-     from: '20240714', // 시작일
+     from: '20240718', // 시작일
      to: '20240731' // 종료일
    });
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[FEATURE][HONEYPOT][EARLYBIRD]

### 💡 작업동기
- 얼리버드로 허니팟 생성 시 티켓정보 언디파인

### 🔑 주요 변경사항
- 얼리버드로 생성한 허니팟은 티켓정보에 얼리버드 정보 출력

### 🏞 스크린샷
![image](https://github.com/user-attachments/assets/c31dbb1a-e7c3-4b92-b354-f9344902f4da)

### 관련 이슈
- 

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
